### PR TITLE
feat: implement base UI components (Button, Card, Badge, Input) (#13)

### DIFF
--- a/docs/tdd/013-base-components.md
+++ b/docs/tdd/013-base-components.md
@@ -1,0 +1,363 @@
+# TDD: Issue #13 - Base Components (Button, Card, Badge, Input)
+
+## Issue Summary
+Create reusable base UI components following the existing design token system. These components will form the foundation of the Flux design system, ensuring consistent styling across the application.
+
+## Acceptance Criteria
+- [x] All 4 components render correctly
+- [x] Button variants (primary, secondary, danger) work as expected
+- [x] Button sizes (sm, md, lg) apply correct styling
+- [x] Card accent bar and hover states function properly
+- [x] Badge variants display correct colors
+- [x] Input styling matches design system
+- [x] All components use CSS variables (no hard-coded colors)
+- [x] Focus states visible for keyboard navigation
+- [x] ARIA attributes where applicable
+
+## Rationale
+Base UI components provide:
+1. **Consistency** - Uniform look and behavior across the application
+2. **Reusability** - Write once, use everywhere
+3. **Accessibility** - Built-in keyboard navigation and ARIA support
+4. **Maintainability** - Centralized styling using design tokens
+
+## Component Specifications
+
+### Button
+- **Variants:** `primary` (cyan filled), `secondary` (ghost with border), `danger` (red)
+- **Sizes:** `sm`, `md` (default), `lg`
+- **States:** default, hover, active, disabled, focus
+
+### Card
+- **Features:** Optional accent bar (top edge), hover states, alert variant (warning border)
+
+### Badge
+- **Variants:** `default` (cyan), `success` (green), `warning` (amber), `error` (red), `muted` (gray)
+
+### Input
+- **Features:** Text input, placeholder styling, focus states, optional icon slot (left), error state
+
+## Failing Tests
+
+### Test 1: Button renders with children
+Buttons must be visible and interactive as the primary action element in the UI.
+```typescript
+it('renders with children', () => {
+  render(<Button>Click me</Button>)
+  expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument()
+})
+```
+
+### Test 2: Button applies primary variant by default
+Primary variant is the default call-to-action style with cyan accent background.
+```typescript
+it('applies primary variant by default', () => {
+  render(<Button>Primary</Button>)
+  expect(screen.getByRole('button')).toHaveClass('button--primary')
+})
+```
+
+### Test 3: Button applies variant classes
+Secondary and danger variants provide visual distinction for different action types.
+```typescript
+it('applies secondary variant when specified', () => {
+  render(<Button variant="secondary">Secondary</Button>)
+  expect(screen.getByRole('button')).toHaveClass('button--secondary')
+})
+
+it('applies danger variant when specified', () => {
+  render(<Button variant="danger">Danger</Button>)
+  expect(screen.getByRole('button')).toHaveClass('button--danger')
+})
+```
+
+### Test 4: Button applies size classes
+Size variants allow buttons to fit different UI contexts (toolbars vs forms).
+```typescript
+it('applies size classes correctly', () => {
+  const { rerender } = render(<Button size="sm">Small</Button>)
+  expect(screen.getByRole('button')).toHaveClass('button--sm')
+
+  rerender(<Button size="lg">Large</Button>)
+  expect(screen.getByRole('button')).toHaveClass('button--lg')
+})
+```
+
+### Test 5: Button handles disabled state
+Disabled state prevents interaction and provides visual indication.
+```typescript
+it('handles disabled state', () => {
+  render(<Button disabled>Disabled</Button>)
+  expect(screen.getByRole('button')).toBeDisabled()
+})
+```
+
+### Test 6: Button click handler
+Click handler enables button functionality; disabled buttons must not trigger actions.
+```typescript
+it('calls onClick when clicked', async () => {
+  const handleClick = jest.fn()
+  render(<Button onClick={handleClick}>Click</Button>)
+  await userEvent.click(screen.getByRole('button'))
+  expect(handleClick).toHaveBeenCalledTimes(1)
+})
+
+it('does not call onClick when disabled', async () => {
+  const handleClick = jest.fn()
+  render(<Button onClick={handleClick} disabled>Click</Button>)
+  await userEvent.click(screen.getByRole('button'))
+  expect(handleClick).not.toHaveBeenCalled()
+})
+```
+
+### Test 7: Card renders children
+Cards are container components that must render their children content.
+```typescript
+it('renders children', () => {
+  render(<Card>Card content</Card>)
+  expect(screen.getByText('Card content')).toBeInTheDocument()
+})
+```
+
+### Test 8: Card accent bar
+Accent bar provides visual hierarchy and categorization via a colored top border.
+```typescript
+it('applies accent bar with custom color', () => {
+  render(<Card accentColor="var(--color-success)">Content</Card>)
+  const card = screen.getByText('Content').closest('.card')
+  expect(card).toHaveClass('card--accent')
+})
+```
+
+### Test 9: Card alert variant
+Alert variant signals important information requiring user attention with warning styling.
+```typescript
+it('applies alert variant', () => {
+  render(<Card alert>Alert content</Card>)
+  const card = screen.getByText('Alert content').closest('.card')
+  expect(card).toHaveClass('card--alert')
+})
+```
+
+### Test 10: Card hoverable styling
+Hoverable cards indicate interactivity for clickable card elements.
+```typescript
+it('applies hoverable styling', () => {
+  render(<Card hoverable>Hover me</Card>)
+  const card = screen.getByText('Hover me').closest('.card')
+  expect(card).toHaveClass('card--hoverable')
+})
+```
+
+### Test 11: Badge renders with children
+Badges display short labels or status indicators inline with other content.
+```typescript
+it('renders with children', () => {
+  render(<Badge>Label</Badge>)
+  expect(screen.getByText('Label')).toBeInTheDocument()
+})
+```
+
+### Test 12: Badge applies variant classes
+Each variant uses semantic colors for its intended purpose (default, success, warning, error, muted).
+```typescript
+it('applies default variant by default', () => {
+  render(<Badge>Default</Badge>)
+  expect(screen.getByText('Default')).toHaveClass('badge--default')
+})
+
+it('applies variant classes correctly', () => {
+  const variants = ['success', 'warning', 'error', 'muted'] as const
+  variants.forEach(variant => {
+    const { unmount } = render(<Badge variant={variant}>{variant}</Badge>)
+    expect(screen.getByText(variant)).toHaveClass(`badge--${variant}`)
+    unmount()
+  })
+})
+```
+
+### Test 13: Input renders with placeholder
+Placeholder provides hint text for expected input content.
+```typescript
+it('renders with placeholder', () => {
+  render(<Input placeholder="Enter text" />)
+  expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument()
+})
+```
+
+### Test 14: Input renders with icon
+Icon slot allows adding visual context like search or user icons.
+```typescript
+it('renders with icon', () => {
+  render(<Input icon={<span data-testid="icon">icon</span>} />)
+  expect(screen.getByTestId('icon')).toBeInTheDocument()
+  expect(screen.getByRole('textbox').closest('.input-wrapper')).toHaveClass('input-wrapper--with-icon')
+})
+```
+
+### Test 15: Input error styling
+Error state provides visual feedback for invalid input via red border.
+```typescript
+it('applies error styling', () => {
+  render(<Input error />)
+  expect(screen.getByRole('textbox')).toHaveClass('input--error')
+})
+```
+
+### Test 16: Input onChange handler
+onChange handler enables controlled input behavior for form state management.
+```typescript
+it('calls onChange with value', async () => {
+  const handleChange = jest.fn()
+  render(<Input onChange={handleChange} />)
+  await userEvent.type(screen.getByRole('textbox'), 'test')
+  expect(handleChange).toHaveBeenLastCalledWith('test')
+})
+
+it('displays controlled value', () => {
+  render(<Input value="controlled" onChange={() => {}} />)
+  expect(screen.getByRole('textbox')).toHaveValue('controlled')
+})
+```
+
+## Expected Output (Failing)
+```
+FAIL frontend/src/__tests__/components/ui.test.tsx
+  Button
+    ✕ renders with children
+    ✕ applies primary variant by default
+    ✕ applies secondary variant when specified
+    ✕ applies danger variant when specified
+    ✕ applies size classes correctly
+    ✕ handles disabled state
+    ✕ calls onClick when clicked
+    ✕ does not call onClick when disabled
+  Card
+    ✕ renders children
+    ✕ applies accent bar with custom color
+    ✕ applies alert variant
+    ✕ applies hoverable styling
+  Badge
+    ✕ renders with children
+    ✕ applies default variant by default
+    ✕ applies variant classes correctly
+  Input
+    ✕ renders with placeholder
+    ✕ renders with icon
+    ✕ applies error styling
+    ✕ calls onChange with value
+    ✕ displays controlled value
+```
+
+## Test Summary
+| Component | Tests | Status |
+|-----------|-------|--------|
+| Button | 11 | Pass |
+| Card | 6 | Pass |
+| Badge | 7 | Pass |
+| Input | 8 | Pass |
+
+## Implementation Summary
+
+### Files to Create
+- `docs/tdd/013-base-components.md` - This TDD document
+- `frontend/src/components/ui/Button/Button.tsx`
+- `frontend/src/components/ui/Button/Button.css`
+- `frontend/src/components/ui/Card/Card.tsx`
+- `frontend/src/components/ui/Card/Card.css`
+- `frontend/src/components/ui/Badge/Badge.tsx`
+- `frontend/src/components/ui/Badge/Badge.css`
+- `frontend/src/components/ui/Input/Input.tsx`
+- `frontend/src/components/ui/Input/Input.css`
+- `frontend/src/components/ui/index.ts`
+- `frontend/src/__tests__/components/ui.test.tsx`
+
+### Files to Modify
+- `frontend/src/components/index.ts` - Add UI component exports
+
+## Passing Test Results
+```
+PASS src/__tests__/components/ui.test.tsx
+  Button
+    ✓ renders with children (55 ms)
+    ✓ applies primary variant by default (6 ms)
+    ✓ applies secondary variant when specified (6 ms)
+    ✓ applies danger variant when specified (8 ms)
+    ✓ applies size classes correctly (8 ms)
+    ✓ applies medium size by default (4 ms)
+    ✓ handles disabled state (3 ms)
+    ✓ calls onClick when clicked (37 ms)
+    ✓ does not call onClick when disabled (15 ms)
+    ✓ supports button type attribute (4 ms)
+    ✓ defaults to type button (3 ms)
+  Card
+    ✓ renders children (2 ms)
+    ✓ applies accent bar with custom color (2 ms)
+    ✓ applies alert variant (2 ms)
+    ✓ applies hoverable styling (1 ms)
+    ✓ has base card class (1 ms)
+    ✓ accepts custom className (1 ms)
+  Badge
+    ✓ renders with children (1 ms)
+    ✓ applies default variant by default (1 ms)
+    ✓ applies success variant (1 ms)
+    ✓ applies warning variant (1 ms)
+    ✓ applies error variant (1 ms)
+    ✓ applies muted variant
+    ✓ has base badge class
+  Input
+    ✓ renders with placeholder (3 ms)
+    ✓ renders with icon (7 ms)
+    ✓ applies error styling (3 ms)
+    ✓ calls onChange with value (29 ms)
+    ✓ displays controlled value (5 ms)
+    ✓ has base input class (4 ms)
+    ✓ handles disabled state (5 ms)
+    ✓ supports type attribute (2 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       32 passed, 32 total
+```
+
+## Implementation Summary
+
+### Files Created
+- `docs/tdd/013-base-components.md` - This TDD document
+- `frontend/src/components/ui/Button/Button.tsx` - Button component with primary/secondary/danger variants and sm/md/lg sizes
+- `frontend/src/components/ui/Button/Button.css` - Button styling using CSS variables
+- `frontend/src/components/ui/Card/Card.tsx` - Card component with accent bar, alert, and hoverable options
+- `frontend/src/components/ui/Card/Card.css` - Card styling using CSS variables
+- `frontend/src/components/ui/Badge/Badge.tsx` - Badge component with 5 variants (default, success, warning, error, muted)
+- `frontend/src/components/ui/Badge/Badge.css` - Badge styling using CSS variables
+- `frontend/src/components/ui/Input/Input.tsx` - Input component with icon slot, error state, and controlled value support
+- `frontend/src/components/ui/Input/Input.css` - Input styling using CSS variables
+- `frontend/src/components/ui/index.ts` - Barrel export for all UI components
+- `frontend/src/__tests__/components/ui.test.tsx` - 32 tests covering all components
+
+### Files Modified
+- `frontend/src/components/index.ts` - Added `export * from './ui'`
+
+### Design Decisions
+
+1. **CSS Variables Only** - All colors, spacing, typography, and other values use design tokens from `tokens.css`. No hard-coded hex values.
+
+2. **BEM-style Naming** - Component classes follow BEM conventions:
+   - `.button`, `.button--primary`, `.button--sm`
+   - `.card`, `.card--accent`, `.card--alert`
+   - `.badge`, `.badge--success`
+   - `.input`, `.input--error`
+
+3. **Focus States** - All interactive components have `:focus-visible` styles for keyboard accessibility using the accent color with offset outline.
+
+4. **Component Structure** - Each component has its own directory with `.tsx` and `.css` files for easy maintenance and code splitting.
+
+5. **Type Exports** - All component props interfaces are exported for type-safe usage across the application.
+
+### Token Usage Summary
+| Token Category | Usage |
+|---------------|-------|
+| Colors | `--color-accent`, `--color-bg-*`, `--color-text-*`, `--color-border-*`, `--color-success`, `--color-warning`, `--color-error` |
+| Spacing | `--spacing-xs`, `--spacing-sm`, `--spacing-md`, `--spacing-lg`, `--spacing-xl` |
+| Typography | `--font-ui`, `--font-size-xs/sm/md`, `--font-weight-medium/semibold` |
+| Layout | `--radius-sm`, `--radius-md`, `--radius-lg` |
+| Transitions | `--transition-fast` |

--- a/frontend/src/__tests__/components/ui.test.tsx
+++ b/frontend/src/__tests__/components/ui.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button, Card, Badge, Input } from '@components/ui'
+
+describe('Button', () => {
+  // Buttons must be visible and interactive as the primary action element.
+  it('renders with children', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument()
+  })
+
+  // Primary variant is the default call-to-action style with cyan accent.
+  it('applies primary variant by default', () => {
+    render(<Button>Primary</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--primary')
+  })
+
+  // Secondary variant provides a subtle alternative for less prominent actions.
+  it('applies secondary variant when specified', () => {
+    render(<Button variant="secondary">Secondary</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--secondary')
+  })
+
+  // Danger variant signals destructive actions like delete or cancel.
+  it('applies danger variant when specified', () => {
+    render(<Button variant="danger">Danger</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--danger')
+  })
+
+  // Size variants allow buttons to fit different UI contexts (toolbars vs forms).
+  it('applies size classes correctly', () => {
+    const { rerender } = render(<Button size="sm">Small</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--sm')
+
+    rerender(<Button size="lg">Large</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--lg')
+  })
+
+  // Medium is the default size, used when no size prop is specified.
+  it('applies medium size by default', () => {
+    render(<Button>Default</Button>)
+    expect(screen.getByRole('button')).toHaveClass('button--md')
+  })
+
+  // Disabled state prevents interaction and applies visual indication.
+  it('handles disabled state', () => {
+    render(<Button disabled>Disabled</Button>)
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  // Click handler enables button functionality.
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const handleClick = jest.fn()
+    render(<Button onClick={handleClick}>Click</Button>)
+    await user.click(screen.getByRole('button'))
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  // Disabled buttons must not trigger actions even if clicked.
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup()
+    const handleClick = jest.fn()
+    render(
+      <Button onClick={handleClick} disabled>
+        Click
+      </Button>
+    )
+    await user.click(screen.getByRole('button'))
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  // Buttons should support standard button types for form submissions.
+  it('supports button type attribute', () => {
+    render(<Button type="submit">Submit</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit')
+  })
+
+  // Default type should be "button" to prevent accidental form submissions.
+  it('defaults to type button', () => {
+    render(<Button>Default</Button>)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+})
+
+describe('Card', () => {
+  // Cards are container components that must render their children.
+  it('renders children', () => {
+    render(<Card>Card content</Card>)
+    expect(screen.getByText('Card content')).toBeInTheDocument()
+  })
+
+  // Accent bar provides visual hierarchy and categorization.
+  it('applies accent bar with custom color', () => {
+    render(<Card accentColor="var(--color-success)">Content</Card>)
+    const card = screen.getByText('Content').closest('.card')
+    expect(card).toHaveClass('card--accent')
+  })
+
+  // Alert variant signals important information requiring attention.
+  it('applies alert variant', () => {
+    render(<Card alert>Alert content</Card>)
+    const card = screen.getByText('Alert content').closest('.card')
+    expect(card).toHaveClass('card--alert')
+  })
+
+  // Hoverable cards indicate interactivity for clickable cards.
+  it('applies hoverable styling', () => {
+    render(<Card hoverable>Hover me</Card>)
+    const card = screen.getByText('Hover me').closest('.card')
+    expect(card).toHaveClass('card--hoverable')
+  })
+
+  // Cards should have the base card class for styling.
+  it('has base card class', () => {
+    render(<Card>Base card</Card>)
+    const card = screen.getByText('Base card').closest('.card')
+    expect(card).toHaveClass('card')
+  })
+
+  // Cards can accept additional className for composition.
+  it('accepts custom className', () => {
+    render(<Card className="custom-class">Custom</Card>)
+    const card = screen.getByText('Custom').closest('.card')
+    expect(card).toHaveClass('card', 'custom-class')
+  })
+})
+
+describe('Badge', () => {
+  // Badges display short labels or status indicators.
+  it('renders with children', () => {
+    render(<Badge>Label</Badge>)
+    expect(screen.getByText('Label')).toBeInTheDocument()
+  })
+
+  // Default variant uses the primary accent color (cyan).
+  it('applies default variant by default', () => {
+    render(<Badge>Default</Badge>)
+    expect(screen.getByText('Default')).toHaveClass('badge--default')
+  })
+
+  // Success variant for positive states like "completed" or "active".
+  it('applies success variant', () => {
+    render(<Badge variant="success">Success</Badge>)
+    expect(screen.getByText('Success')).toHaveClass('badge--success')
+  })
+
+  // Warning variant for caution states requiring attention.
+  it('applies warning variant', () => {
+    render(<Badge variant="warning">Warning</Badge>)
+    expect(screen.getByText('Warning')).toHaveClass('badge--warning')
+  })
+
+  // Error variant for failure states or critical issues.
+  it('applies error variant', () => {
+    render(<Badge variant="error">Error</Badge>)
+    expect(screen.getByText('Error')).toHaveClass('badge--error')
+  })
+
+  // Muted variant for de-emphasized or secondary information.
+  it('applies muted variant', () => {
+    render(<Badge variant="muted">Muted</Badge>)
+    expect(screen.getByText('Muted')).toHaveClass('badge--muted')
+  })
+
+  // Badges should have the base badge class for styling.
+  it('has base badge class', () => {
+    render(<Badge>Base</Badge>)
+    expect(screen.getByText('Base')).toHaveClass('badge')
+  })
+})
+
+describe('Input', () => {
+  // Input placeholder provides hint text for expected input.
+  it('renders with placeholder', () => {
+    render(<Input placeholder="Enter text" />)
+    expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument()
+  })
+
+  // Icon slot allows adding visual context (search, user, etc.).
+  it('renders with icon', () => {
+    render(<Input icon={<span data-testid="icon">icon</span>} />)
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByRole('textbox').closest('.input-wrapper')).toHaveClass(
+      'input-wrapper--with-icon'
+    )
+  })
+
+  // Error state provides visual feedback for invalid input.
+  it('applies error styling', () => {
+    render(<Input error />)
+    expect(screen.getByRole('textbox')).toHaveClass('input--error')
+  })
+
+  // onChange handler enables controlled input behavior.
+  it('calls onChange with value', async () => {
+    const user = userEvent.setup()
+    const handleChange = jest.fn()
+    render(<Input onChange={handleChange} />)
+    await user.type(screen.getByRole('textbox'), 'test')
+    expect(handleChange).toHaveBeenLastCalledWith('test')
+  })
+
+  // Controlled value enables form state management.
+  it('displays controlled value', () => {
+    render(<Input value="controlled" onChange={() => {}} />)
+    expect(screen.getByRole('textbox')).toHaveValue('controlled')
+  })
+
+  // Input should have the base input class for styling.
+  it('has base input class', () => {
+    render(<Input />)
+    expect(screen.getByRole('textbox')).toHaveClass('input')
+  })
+
+  // Disabled state prevents interaction.
+  it('handles disabled state', () => {
+    render(<Input disabled />)
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
+  // Input should support standard text input types.
+  it('supports type attribute', () => {
+    render(<Input type="password" />)
+    // Password type doesn't use textbox role
+    expect(screen.getByDisplayValue('')).toHaveAttribute('type', 'password')
+  })
+})

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as App } from './App'
 export * from './layout'
+export * from './ui'

--- a/frontend/src/components/ui/Badge/Badge.css
+++ b/frontend/src/components/ui/Badge/Badge.css
@@ -1,0 +1,40 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  line-height: var(--line-height-tight);
+}
+
+/* Default variant - cyan accent */
+.badge--default {
+  background: var(--color-accent-dim);
+  color: var(--color-accent-bright);
+}
+
+/* Success variant - green */
+.badge--success {
+  background: var(--color-success-dim);
+  color: var(--color-success);
+}
+
+/* Warning variant - amber */
+.badge--warning {
+  background: var(--color-warning-dim);
+  color: var(--color-warning);
+}
+
+/* Error variant - red */
+.badge--error {
+  background: var(--color-error-dim);
+  color: var(--color-error);
+}
+
+/* Muted variant - subtle gray */
+.badge--muted {
+  background: var(--color-bg-active);
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/components/ui/Badge/Badge.tsx
+++ b/frontend/src/components/ui/Badge/Badge.tsx
@@ -1,0 +1,13 @@
+import './Badge.css'
+
+export interface BadgeProps {
+  variant?: 'default' | 'success' | 'warning' | 'error' | 'muted'
+  className?: string
+  children: React.ReactNode
+}
+
+export function Badge({ variant = 'default', className: customClassName, children }: BadgeProps) {
+  const className = ['badge', `badge--${variant}`, customClassName].filter(Boolean).join(' ')
+
+  return <span className={className}>{children}</span>
+}

--- a/frontend/src/components/ui/Button/Button.css
+++ b/frontend/src/components/ui/Button/Button.css
@@ -1,0 +1,90 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-ui);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  border: 1px solid transparent;
+}
+
+/* Sizes */
+.button--sm {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+}
+
+.button--md {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm);
+}
+
+.button--lg {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: var(--font-size-md);
+}
+
+/* Primary variant - cyan accent filled */
+.button--primary {
+  background: var(--color-accent);
+  color: var(--color-bg-base);
+  border-color: var(--color-accent);
+}
+
+.button--primary:hover:not(:disabled) {
+  background: var(--color-accent-bright);
+  border-color: var(--color-accent-bright);
+}
+
+.button--primary:active:not(:disabled) {
+  background: var(--color-accent);
+  transform: translateY(1px);
+}
+
+/* Secondary variant - ghost with border */
+.button--secondary {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-muted);
+}
+
+.button--secondary:hover:not(:disabled) {
+  background: var(--color-bg-active);
+  border-color: var(--color-border-default);
+}
+
+.button--secondary:active:not(:disabled) {
+  background: var(--color-bg-hover);
+  transform: translateY(1px);
+}
+
+/* Danger variant - red for destructive actions */
+.button--danger {
+  background: var(--color-error);
+  color: var(--color-text-primary);
+  border-color: var(--color-error);
+}
+
+.button--danger:hover:not(:disabled) {
+  background: var(--color-error);
+  filter: brightness(1.1);
+}
+
+.button--danger:active:not(:disabled) {
+  filter: brightness(0.95);
+  transform: translateY(1px);
+}
+
+/* Disabled state */
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Focus state for accessibility */
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/ui/Button/Button.tsx
+++ b/frontend/src/components/ui/Button/Button.tsx
@@ -1,0 +1,31 @@
+import './Button.css'
+
+export interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'danger'
+  size?: 'sm' | 'md' | 'lg'
+  disabled?: boolean
+  type?: 'button' | 'submit' | 'reset'
+  className?: string
+  children: React.ReactNode
+  onClick?: () => void
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  type = 'button',
+  className: customClassName,
+  children,
+  onClick,
+}: ButtonProps) {
+  const className = ['button', `button--${variant}`, `button--${size}`, customClassName]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <button className={className} disabled={disabled} type={type} onClick={onClick}>
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/ui/Card/Card.css
+++ b/frontend/src/components/ui/Card/Card.css
@@ -1,0 +1,38 @@
+.card {
+  background: var(--color-bg-panel);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  transition: all var(--transition-fast);
+}
+
+/* Accent bar - top edge with custom color */
+.card--accent {
+  border-top: 3px solid var(--card-accent-color, var(--color-accent));
+}
+
+/* Alert variant - warning border */
+.card--alert {
+  border-color: var(--color-warning);
+  background: var(--color-warning-subtle);
+}
+
+/* Hoverable - for clickable cards */
+.card--hoverable {
+  cursor: pointer;
+}
+
+.card--hoverable:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-default);
+}
+
+.card--hoverable:active {
+  background: var(--color-bg-active);
+}
+
+/* Focus state for accessibility */
+.card:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/ui/Card/Card.tsx
+++ b/frontend/src/components/ui/Card/Card.tsx
@@ -1,0 +1,31 @@
+import './Card.css'
+
+export interface CardProps {
+  accentColor?: string
+  alert?: boolean
+  hoverable?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+export function Card({ accentColor, alert, hoverable, className, children }: CardProps) {
+  const classes = [
+    'card',
+    accentColor && 'card--accent',
+    alert && 'card--alert',
+    hoverable && 'card--hoverable',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const style = accentColor
+    ? ({ '--card-accent-color': accentColor } as React.CSSProperties)
+    : undefined
+
+  return (
+    <div className={classes} style={style}>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Input/Input.css
+++ b/frontend/src/components/ui/Input/Input.css
@@ -1,0 +1,61 @@
+.input-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.input-wrapper--with-icon .input {
+  padding-left: calc(var(--spacing-xl) + var(--spacing-xs));
+}
+
+.input__icon {
+  position: absolute;
+  left: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  color: var(--color-text-muted);
+  pointer-events: none;
+}
+
+.input {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  background: var(--color-bg-content);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-md);
+  transition: all var(--transition-fast);
+}
+
+.input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.input:hover:not(:disabled) {
+  border-color: var(--color-border-default);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-dim);
+}
+
+/* Error state */
+.input--error {
+  border-color: var(--color-error);
+}
+
+.input--error:focus {
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 2px var(--color-error-dim);
+}
+
+/* Disabled state */
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: var(--color-bg-hover);
+}

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -1,0 +1,53 @@
+import './Input.css'
+
+export interface InputProps {
+  placeholder?: string
+  icon?: React.ReactNode
+  error?: boolean
+  value?: string
+  disabled?: boolean
+  type?: string
+  name?: string
+  id?: string
+  className?: string
+  onChange?: (value: string) => void
+}
+
+export function Input({
+  placeholder,
+  icon,
+  error,
+  value,
+  disabled,
+  type = 'text',
+  name,
+  id,
+  className: customClassName,
+  onChange,
+}: InputProps) {
+  const wrapperClasses = ['input-wrapper', icon && 'input-wrapper--with-icon']
+    .filter(Boolean)
+    .join(' ')
+
+  const inputClasses = ['input', error && 'input--error', customClassName].filter(Boolean).join(' ')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange?.(e.target.value)
+  }
+
+  return (
+    <div className={wrapperClasses}>
+      {icon && <span className="input__icon">{icon}</span>}
+      <input
+        className={inputClasses}
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        name={name}
+        id={id}
+        onChange={handleChange}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,11 @@
+export { Button } from './Button/Button'
+export type { ButtonProps } from './Button/Button'
+
+export { Card } from './Card/Card'
+export type { CardProps } from './Card/Card'
+
+export { Badge } from './Badge/Badge'
+export type { BadgeProps } from './Badge/Badge'
+
+export { Input } from './Input/Input'
+export type { InputProps } from './Input/Input'

--- a/frontend/src/components/views/CodeView.tsx
+++ b/frontend/src/components/views/CodeView.tsx
@@ -57,7 +57,7 @@ export function CodeView({ layout }: CodeViewProps) {
 
   // Code view has no right column, so we use a 2-column layout
   const contentStyle = {
-    '--panel-left-width': layout.leftCollapsed ? '24px' : `${leftResize.size}px`,
+    '--panel-left-width': layout.leftCollapsed ? '0px' : `${leftResize.size}px`,
     '--panel-right-width': '0px',
     '--panel-output-height': layout.outputCollapsed ? '36px' : `${outputResize.size}px`,
   } as CSSProperties
@@ -67,31 +67,30 @@ export function CodeView({ layout }: CodeViewProps) {
 
   return (
     <div className="content content--code" data-testid="code-view" style={contentStyle}>
+      {/* Expand button when left is collapsed */}
+      {layout.leftCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-left"
+          data-testid="expand-left"
+          onClick={() => layout.setLeftCollapsed(false)}
+          aria-label="Expand left panel"
+        >
+          <ChevronRightIcon />
+        </button>
+      )}
+
       {/* Left column - File tree */}
       <div className={leftColumnClasses} data-testid="left-column">
-        {layout.leftCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-left"
-            onClick={() => layout.setLeftCollapsed(false)}
-            aria-label="Expand left panel"
-          >
-            <ChevronRightIcon />
-          </button>
-        ) : (
-          <>
-            <FileTreePanel />
+        <FileTreePanel />
 
-            <button
-              className="collapse-btn collapse-btn--left-edge"
-              data-testid="collapse-left"
-              onClick={() => layout.setLeftCollapsed(true)}
-              aria-label="Collapse left panel"
-            >
-              <ChevronLeftIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--left-edge"
+          data-testid="collapse-left"
+          onClick={() => layout.setLeftCollapsed(true)}
+          aria-label="Collapse left panel"
+        >
+          <ChevronLeftIcon />
+        </button>
       </div>
 
       {!layout.leftCollapsed && (

--- a/frontend/src/components/views/CompareView.tsx
+++ b/frontend/src/components/views/CompareView.tsx
@@ -68,8 +68,8 @@ export function CompareView({ layout }: CompareViewProps) {
   })
 
   const contentStyle = {
-    '--panel-left-width': layout.leftCollapsed ? '24px' : `${leftResize.size}px`,
-    '--panel-right-width': layout.rightCollapsed ? '24px' : `${rightResize.size}px`,
+    '--panel-left-width': layout.leftCollapsed ? '0px' : `${leftResize.size}px`,
+    '--panel-right-width': layout.rightCollapsed ? '0px' : `${rightResize.size}px`,
     '--panel-output-height': layout.outputCollapsed ? '36px' : `${outputResize.size}px`,
   } as CSSProperties
 
@@ -79,31 +79,30 @@ export function CompareView({ layout }: CompareViewProps) {
 
   return (
     <div className="content content--compare" data-testid="compare-view" style={contentStyle}>
+      {/* Expand button when left is collapsed */}
+      {layout.leftCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-left"
+          data-testid="expand-left"
+          onClick={() => layout.setLeftCollapsed(false)}
+          aria-label="Expand left panel"
+        >
+          <ChevronRightIcon />
+        </button>
+      )}
+
       {/* Left column - Experiment selection */}
       <div className={leftColumnClasses} data-testid="left-column">
-        {layout.leftCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-left"
-            onClick={() => layout.setLeftCollapsed(false)}
-            aria-label="Expand left panel"
-          >
-            <ChevronRightIcon />
-          </button>
-        ) : (
-          <>
-            <ExperimentSelectionPanel />
+        <ExperimentSelectionPanel />
 
-            <button
-              className="collapse-btn collapse-btn--left-edge"
-              data-testid="collapse-left"
-              onClick={() => layout.setLeftCollapsed(true)}
-              aria-label="Collapse left panel"
-            >
-              <ChevronLeftIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--left-edge"
+          data-testid="collapse-left"
+          onClick={() => layout.setLeftCollapsed(true)}
+          aria-label="Collapse left panel"
+        >
+          <ChevronLeftIcon />
+        </button>
       </div>
 
       {!layout.leftCollapsed && (
@@ -144,31 +143,30 @@ export function CompareView({ layout }: CompareViewProps) {
         />
       )}
 
+      {/* Expand button when right is collapsed */}
+      {layout.rightCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-right"
+          data-testid="expand-right"
+          onClick={() => layout.setRightCollapsed(false)}
+          aria-label="Expand right panel"
+        >
+          <ChevronLeftIcon />
+        </button>
+      )}
+
       {/* Right column - Analysis */}
       <div className={rightColumnClasses} data-testid="right-column">
-        {layout.rightCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-right"
-            onClick={() => layout.setRightCollapsed(false)}
-            aria-label="Expand right panel"
-          >
-            <ChevronLeftIcon />
-          </button>
-        ) : (
-          <>
-            <AnalysisPanel />
+        <AnalysisPanel />
 
-            <button
-              className="collapse-btn collapse-btn--right-edge"
-              data-testid="collapse-right"
-              onClick={() => layout.setRightCollapsed(true)}
-              aria-label="Collapse right panel"
-            >
-              <ChevronRightIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--right-edge"
+          data-testid="collapse-right"
+          onClick={() => layout.setRightCollapsed(true)}
+          aria-label="Collapse right panel"
+        >
+          <ChevronRightIcon />
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/views/DataView.tsx
+++ b/frontend/src/components/views/DataView.tsx
@@ -77,8 +77,8 @@ export function DataView({ layout }: DataViewProps) {
   })
 
   const contentStyle = {
-    '--panel-left-width': layout.leftCollapsed ? '24px' : `${leftResize.size}px`,
-    '--panel-right-width': layout.rightCollapsed ? '24px' : `${rightResize.size}px`,
+    '--panel-left-width': layout.leftCollapsed ? '0px' : `${leftResize.size}px`,
+    '--panel-right-width': layout.rightCollapsed ? '0px' : `${rightResize.size}px`,
     '--panel-output-height': layout.outputCollapsed ? '36px' : `${outputResize.size}px`,
     '--panel-left-top-height': `${leftRowResize.size}px`,
   } as CSSProperties
@@ -89,39 +89,38 @@ export function DataView({ layout }: DataViewProps) {
 
   return (
     <div className="content content--data" data-testid="data-view" style={contentStyle}>
+      {/* Expand button when left is collapsed */}
+      {layout.leftCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-left"
+          data-testid="expand-left"
+          onClick={() => layout.setLeftCollapsed(false)}
+          aria-label="Expand left panel"
+        >
+          <ChevronRightIcon />
+        </button>
+      )}
+
       {/* Left column - Datasets and Quality */}
       <div className={leftColumnClasses} data-testid="left-column">
-        {layout.leftCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-left"
-            onClick={() => layout.setLeftCollapsed(false)}
-            aria-label="Expand left panel"
-          >
-            <ChevronRightIcon />
-          </button>
-        ) : (
-          <>
-            <DatasetsPanel />
+        <DatasetsPanel />
 
-            <div
-              className="resize-handle resize-handle--horizontal resize-handle--left-row"
-              data-testid="resize-handle-left-row"
-              onMouseDown={leftRowResize.handleMouseDown}
-            />
+        <div
+          className="resize-handle resize-handle--horizontal resize-handle--left-row"
+          data-testid="resize-handle-left-row"
+          onMouseDown={leftRowResize.handleMouseDown}
+        />
 
-            <QualityPanel />
+        <QualityPanel />
 
-            <button
-              className="collapse-btn collapse-btn--left-edge"
-              data-testid="collapse-left"
-              onClick={() => layout.setLeftCollapsed(true)}
-              aria-label="Collapse left panel"
-            >
-              <ChevronLeftIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--left-edge"
+          data-testid="collapse-left"
+          onClick={() => layout.setLeftCollapsed(true)}
+          aria-label="Collapse left panel"
+        >
+          <ChevronLeftIcon />
+        </button>
       </div>
 
       {!layout.leftCollapsed && (
@@ -162,31 +161,30 @@ export function DataView({ layout }: DataViewProps) {
         />
       )}
 
+      {/* Expand button when right is collapsed */}
+      {layout.rightCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-right"
+          data-testid="expand-right"
+          onClick={() => layout.setRightCollapsed(false)}
+          aria-label="Expand right panel"
+        >
+          <ChevronLeftIcon />
+        </button>
+      )}
+
       {/* Right column - Sample Inspector */}
       <div className={rightColumnClasses} data-testid="right-column">
-        {layout.rightCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-right"
-            onClick={() => layout.setRightCollapsed(false)}
-            aria-label="Expand right panel"
-          >
-            <ChevronLeftIcon />
-          </button>
-        ) : (
-          <>
-            <SampleInspectorPanel />
+        <SampleInspectorPanel />
 
-            <button
-              className="collapse-btn collapse-btn--right-edge"
-              data-testid="collapse-right"
-              onClick={() => layout.setRightCollapsed(true)}
-              aria-label="Collapse right panel"
-            >
-              <ChevronRightIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--right-edge"
+          data-testid="collapse-right"
+          onClick={() => layout.setRightCollapsed(true)}
+          aria-label="Collapse right panel"
+        >
+          <ChevronRightIcon />
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/views/ExperimentsView.tsx
+++ b/frontend/src/components/views/ExperimentsView.tsx
@@ -85,8 +85,8 @@ export function ExperimentsView({ layout }: ExperimentsViewProps) {
   })
 
   const contentStyle = {
-    '--panel-left-width': layout.leftCollapsed ? '24px' : `${leftResize.size}px`,
-    '--panel-right-width': layout.rightCollapsed ? '24px' : `${rightResize.size}px`,
+    '--panel-left-width': layout.leftCollapsed ? '0px' : `${leftResize.size}px`,
+    '--panel-right-width': layout.rightCollapsed ? '0px' : `${rightResize.size}px`,
     '--panel-output-height': layout.outputCollapsed ? '36px' : `${outputResize.size}px`,
     '--panel-left-top-height': `${leftRowResize.size}px`,
     '--panel-right-top-height': `${rightRowResize.size}px`,
@@ -98,39 +98,38 @@ export function ExperimentsView({ layout }: ExperimentsViewProps) {
 
   return (
     <div className="content" data-testid="experiments-view" style={contentStyle}>
+      {/* Expand button when left is collapsed */}
+      {layout.leftCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-left"
+          data-testid="expand-left"
+          onClick={() => layout.setLeftCollapsed(false)}
+          aria-label="Expand left panel"
+        >
+          <ChevronRightIcon />
+        </button>
+      )}
+
       {/* Left column */}
       <div className={leftColumnClasses} data-testid="left-column">
-        {layout.leftCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-left"
-            onClick={() => layout.setLeftCollapsed(false)}
-            aria-label="Expand left panel"
-          >
-            <ChevronRightIcon />
-          </button>
-        ) : (
-          <>
-            <ExperimentsPanel />
+        <ExperimentsPanel />
 
-            <div
-              className="resize-handle resize-handle--horizontal resize-handle--left-row"
-              data-testid="resize-handle-left-row"
-              onMouseDown={leftRowResize.handleMouseDown}
-            />
+        <div
+          className="resize-handle resize-handle--horizontal resize-handle--left-row"
+          data-testid="resize-handle-left-row"
+          onMouseDown={leftRowResize.handleMouseDown}
+        />
 
-            <FilesPanel />
+        <FilesPanel />
 
-            <button
-              className="collapse-btn collapse-btn--left-edge"
-              data-testid="collapse-left"
-              onClick={() => layout.setLeftCollapsed(true)}
-              aria-label="Collapse left panel"
-            >
-              <ChevronLeftIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--left-edge"
+          data-testid="collapse-left"
+          onClick={() => layout.setLeftCollapsed(true)}
+          aria-label="Collapse left panel"
+        >
+          <ChevronLeftIcon />
+        </button>
       </div>
 
       {!layout.leftCollapsed && (
@@ -171,39 +170,38 @@ export function ExperimentsView({ layout }: ExperimentsViewProps) {
         />
       )}
 
+      {/* Expand button when right is collapsed */}
+      {layout.rightCollapsed && (
+        <button
+          className="collapse-btn collapse-btn--expand-right"
+          data-testid="expand-right"
+          onClick={() => layout.setRightCollapsed(false)}
+          aria-label="Expand right panel"
+        >
+          <ChevronLeftIcon />
+        </button>
+      )}
+
       {/* Right column */}
       <div className={rightColumnClasses} data-testid="right-column">
-        {layout.rightCollapsed ? (
-          <button
-            className="collapse-btn collapse-btn--edge"
-            data-testid="expand-right"
-            onClick={() => layout.setRightCollapsed(false)}
-            aria-label="Expand right panel"
-          >
-            <ChevronLeftIcon />
-          </button>
-        ) : (
-          <>
-            <InspectorPanel />
+        <InspectorPanel />
 
-            <div
-              className="resize-handle resize-handle--horizontal resize-handle--right-row"
-              data-testid="resize-handle-right-row"
-              onMouseDown={rightRowResize.handleMouseDown}
-            />
+        <div
+          className="resize-handle resize-handle--horizontal resize-handle--right-row"
+          data-testid="resize-handle-right-row"
+          onMouseDown={rightRowResize.handleMouseDown}
+        />
 
-            <ConfigPanel />
+        <ConfigPanel />
 
-            <button
-              className="collapse-btn collapse-btn--right-edge"
-              data-testid="collapse-right"
-              onClick={() => layout.setRightCollapsed(true)}
-              aria-label="Collapse right panel"
-            >
-              <ChevronRightIcon />
-            </button>
-          </>
-        )}
+        <button
+          className="collapse-btn collapse-btn--right-edge"
+          data-testid="collapse-right"
+          onClick={() => layout.setRightCollapsed(true)}
+          aria-label="Collapse right panel"
+        >
+          <ChevronRightIcon />
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/styles/components/layout.css
+++ b/frontend/src/styles/components/layout.css
@@ -837,9 +837,21 @@ body.resizing-row * {
   z-index: var(--z-sticky);
 }
 
-/* Expand button centered in collapsed bar */
-.collapse-btn--edge {
-  margin: auto;
+/* Expand button positioned at edge when panel is fully collapsed */
+.collapse-btn--expand-left {
+  position: absolute;
+  left: var(--panel-gap);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: var(--z-sticky);
+}
+
+.collapse-btn--expand-right {
+  position: absolute;
+  right: var(--panel-gap);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: var(--z-sticky);
 }
 
 /* Column containers need relative positioning for absolute buttons */
@@ -848,15 +860,10 @@ body.resizing-row * {
   position: relative;
 }
 
-/* Collapsed column states */
+/* Collapsed column states - fully hidden */
 .content__left-column--collapsed,
 .content__right-column--collapsed {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-bg-panel);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--color-border-muted);
+  display: none;
 }
 
 /* Collapsed output panel */
@@ -951,7 +958,8 @@ body.resizing-row * {
   border-color: var(--color-border-muted);
 }
 
-.experiment-item--selected {
+.experiment-item--selected,
+.experiment-item--selected:hover {
   background: var(--color-accent-dim);
   border-color: var(--color-accent-muted);
 }
@@ -1714,7 +1722,8 @@ body.resizing-row * {
   border-color: var(--color-border-muted);
 }
 
-.dataset-item--active {
+.dataset-item--active,
+.dataset-item--active:hover {
   background: var(--color-accent-dim);
   border-color: var(--color-accent-glow);
 }
@@ -2621,7 +2630,8 @@ body.resizing-row * {
   background: var(--color-bg-hover);
 }
 
-.file-tree-item--selected {
+.file-tree-item--selected,
+.file-tree-item--selected:hover {
   background: var(--color-accent-dim);
   color: var(--color-text-primary);
 }


### PR DESCRIPTION
## Summary
- Add reusable Button, Card, Badge, and Input components following the design token system
- Fix hover state overriding selected state for dataset/experiment/file tree items
- Change panel collapse to fully hide panels (0px) instead of showing thin bar (24px)

## Components

### Button
- Variants: `primary` (cyan filled), `secondary` (ghost), `danger` (red)
- Sizes: `sm`, `md`, `lg`
- Props: `variant`, `size`, `disabled`, `type`, `className`, `onClick`

### Card  
- Features: accent bar (custom color), alert variant, hoverable state
- Props: `accentColor`, `alert`, `hoverable`, `className`

### Badge
- Variants: `default`, `success`, `warning`, `error`, `muted`
- Props: `variant`, `className`

### Input
- Features: icon slot, error state, controlled value
- Props: `placeholder`, `icon`, `error`, `value`, `disabled`, `type`, `name`, `id`, `className`, `onChange`

## Bug Fixes
- Selected items (datasets, experiments, files) now maintain accent styling when hovered
- Panels collapse completely to 0px width, giving full space to main content

## Test plan
- [x] All 32 new UI component tests pass
- [x] All 92 total tests pass
- [x] ESLint passes with 0 warnings
- [x] No hard-coded colors in CSS (uses design tokens)
- [x] Visual verification of components in browser
- [x] Verify panel collapse/expand works correctly

Generated with [Claude Code](https://claude.ai/code)