### PR TITLE
feat: metrics and reward signal storage (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,20 @@ wails build
 
 This project is in active development. See the [GitHub Issues](https://github.com/kstruzzieri/flux-ml/issues) for the roadmap.
 
+### Completed
+
+- **Phase 1: Foundation** — Wails setup, core UI shell with resizable panels, icon system, design tokens
+- **Phase 2A: Data Layer** — SQLite integration, experiment CRUD, event sourcing, metrics storage (59 tests across 4 packages)
+
 ### Phases
 
 1. **Foundation** - Wails setup, core infrastructure
-2. **File System** - File explorer, editor, workspace management
-3. **Editor Core** - CodeMirror integration, syntax highlighting
-4. **Run System** - Run profiles, terminal integration
-5. **ML Features** - Visualizations, metrics, experiment tracking
-6. **Polish** - Performance optimization, packaging
+2. **Data Layer** - SQLite, experiment management, event sourcing, metrics storage
+3. **File System** - File explorer, editor, workspace management
+4. **Editor Core** - CodeMirror integration, syntax highlighting
+5. **Run System** - Run profiles, terminal integration
+6. **ML Features** - Visualizations, metrics, experiment tracking
+7. **Polish** - Performance optimization, packaging
 
 ## Architecture
 
@@ -73,6 +79,11 @@ This project is in active development. See the [GitHub Issues](https://github.co
 flux-ml/
 ├── main.go              # Application entry point
 ├── app.go               # Wails application logic / Go backend
+├── internal/            # Go backend packages
+│   ├── database/        # SQLite infrastructure, migrations
+│   ├── experiment/      # Experiment CRUD store
+│   ├── event/           # Event sourcing store
+│   └── metrics/         # Metrics and reward signal storage
 ├── frontend/            # React + TypeScript frontend
 │   ├── src/
 │   │   ├── components/  # React components
@@ -92,7 +103,7 @@ Key technical choices and their rationale:
 | CSS | Vanilla CSS + BEM | Zero runtime overhead, optimal for fixed desktop UI |
 | State | React built-in | Sufficient for Phase 1; evaluate libraries as complexity grows |
 | Charts | uPlot (planned) | Lightweight Canvas-based, handles 100k+ points |
-| Database | SQLite (planned) | Embedded, no server, works offline |
+| Database | SQLite (`modernc.org/sqlite`) | Embedded, pure Go, no CGo, works offline |
 
 See [`docs/plan/08-frontend-architecture.md`](docs/plan/08-frontend-architecture.md) for detailed documentation.
 

--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kstruzzieri/flux-ml/internal/database"
 	"github.com/kstruzzieri/flux-ml/internal/event"
 	"github.com/kstruzzieri/flux-ml/internal/experiment"
+	"github.com/kstruzzieri/flux-ml/internal/metrics"
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
@@ -20,6 +21,7 @@ type App struct {
 	db          *database.DB
 	experiments *experiment.Store
 	events      *event.Store
+	metrics     *metrics.Store
 	dbError     string
 }
 
@@ -71,6 +73,7 @@ func (a *App) startup(ctx context.Context) {
 	a.db = db
 	a.experiments = experiment.NewStore(db)
 	a.events = event.NewStore(db)
+	a.metrics = metrics.NewStore(db)
 }
 
 // GetDBStatus returns the database initialization error, or empty string if OK.

--- a/docs/plan/09-data-layer.md
+++ b/docs/plan/09-data-layer.md
@@ -280,10 +280,10 @@ type Store struct {
 | Query filtering | experiment + name/component + step range | Covers chart and detail view use cases |
 | experimentID required | Always required on queries | Prevents full-table scans |
 
-### Test plan (15 tests)
+### Test plan (17 tests)
 
 RecordMetrics (4): Batch insert success, empty experimentID error, empty metrics slice error, FK violation error.
-QueryMetrics (4): Returns all for experiment, filter by name, filter by step range, no matches returns empty slice.
+QueryMetrics (5): Empty experimentID error, returns all for experiment, filter by name, filter by step range, no matches returns empty slice.
 RecordRewardSignals (3): Batch insert with distribution JSON, empty experimentID error, empty signals slice error.
-QueryRewardSignals (3): Returns all for experiment, filter by component, filter by step range.
+QueryRewardSignals (4): Empty experimentID error, returns all for experiment, filter by component, filter by step range.
 Cascade delete (1): Deleting experiment cascades to both metrics and reward_signals.

--- a/docs/plan/09-data-layer.md
+++ b/docs/plan/09-data-layer.md
@@ -1,6 +1,6 @@
 # Data Layer Implementation Plan
 
-This document covers the full backend data layer: SQLite infrastructure, experiment CRUD, and event sourcing. These correspond to issues #16, #17, and #18 in the roadmap (Phase 2A: Data Layer).
+This document covers the full backend data layer: SQLite infrastructure, experiment CRUD, event sourcing, and metrics storage. These correspond to issues #16, #17, #18, and #19 in the roadmap (Phase 2A: Data Layer).
 
 ## Overview
 
@@ -8,7 +8,8 @@ This document covers the full backend data layer: SQLite infrastructure, experim
 |-------|-----------|---------|--------|
 | #16 | SQLite integration | `internal/database/` | Complete |
 | #17 | Experiment CRUD | `internal/experiment/` | Complete |
-| #18 | Event store | `internal/event/` | In Progress |
+| #18 | Event store | `internal/event/` | Complete |
+| #19 | Metrics storage | `internal/metrics/` | In Progress |
 
 ## Shared Architecture
 
@@ -172,52 +173,22 @@ Delete (2): Success removes from DB, not found errors.
 
 ## Issue #18: Event Store
 
-**Branch:** `feature/18-event-store` (current)
-**TDD doc:** `docs/tdd/018-event-store.md` (to be created)
+**Branch:** `feature/18-event-store` (merged)
+**TDD doc:** `docs/tdd/018-event-store.md`
 
-### What will be built
+### What was built
 
 Domain package (`internal/event/`) providing:
 
 - **`store.go`** — `Event` struct, type constants, `Store` with Append/Replay/Subscribe/Unsubscribe
-- **`store_test.go`** — 13 tests
+- **`store_test.go`** — 14 tests
 
 Wails integration:
 
 - **`event_api.go`** — AppendEvent + ReplayEvents pass-through methods on `App`
 - **`app.go`** — Add `events *event.Store` field and initialization
 
-### Data types
-
-```go
-type Event struct {
-    ID           int64  `json:"id"`
-    ExperimentID string `json:"experiment_id"`
-    Timestamp    int64  `json:"timestamp"`
-    Type         string `json:"type"`
-    Data         string `json:"data"`
-}
-
-const (
-    TypeMetric       = "metric"
-    TypeConfigChange = "config_change"
-    TypeAlert        = "alert"
-    TypeCheckpoint   = "checkpoint"
-)
-
-type Subscription struct {
-    ch           chan Event
-    experimentID string  // empty = all events
-    id           int
-}
-
-type Store struct {
-    db          *database.DB
-    mu          sync.RWMutex
-    subscribers map[int]*Subscription
-    nextID      int
-}
-```
+Also added migration `003_cascade_deletes.sql` — ON DELETE CASCADE for all child tables.
 
 ### API
 
@@ -239,18 +210,79 @@ type Store struct {
 | Notification | Non-blocking send, buffered channel (64) | Slow subscriber doesn't block writes |
 | Wails exposure | Append + Replay only | Subscribe/Unsubscribe are internal Go APIs |
 
-### Test plan (13 tests)
+### Tests (14 passing)
 
 Append (4): Success with ID/timestamp/fields, empty experimentID error, invalid type error, FK violation error.
 Replay (6): Chronological order (ASC), filter by experiment, filter by time range, filter by type, combined filters, no matches returns empty slice.
-Subscribe (3): Receives appended events, filtered by experiment ID, unsubscribe stops delivery.
+Subscribe (2): Receives appended events, filtered by experiment ID.
+Other (2): Unsubscribe stops delivery, cascade delete removes events.
 
-### Implementation steps
+---
 
-1. Create TDD doc (`docs/tdd/018-event-store.md`)
-2. Write failing tests (`internal/event/store_test.go`) with minimal stub (`store.go`)
-3. Implement store methods
-4. Verify all 13 tests pass
-5. Add Wails API (`event_api.go`) and wire in `app.go`
-6. Run full test suite (database + experiment + event)
-7. Update TDD doc with results
+## Issue #19: Metrics Storage
+
+**Branch:** `feature/19-metrics-storage` (current)
+**TDD doc:** `docs/tdd/019-metrics-storage.md` (to be created)
+
+### What will be built
+
+Domain package (`internal/metrics/`) providing:
+
+- **`store.go`** — `Metric` struct, `RewardSignal` struct, `Store` with RecordMetrics/QueryMetrics/RecordRewardSignals/QueryRewardSignals
+- **`store_test.go`** — 14 tests
+
+Wails integration:
+
+- **`metrics_api.go`** — Pass-through methods on `App` struct
+- **`app.go`** — Add `metrics *metrics.Store` field and initialization
+
+No new migrations needed — `metrics` and `reward_signals` tables already exist (001 + 003).
+
+### Data types
+
+```go
+type Metric struct {
+    ExperimentID string  `json:"experiment_id"`
+    Step         int64   `json:"step"`
+    Name         string  `json:"name"`
+    Value        float64 `json:"value"`
+    Timestamp    int64   `json:"timestamp"`
+}
+
+type RewardSignal struct {
+    ExperimentID string  `json:"experiment_id"`
+    Step         int64   `json:"step"`
+    Component    string  `json:"component"`
+    Value        float64 `json:"value"`
+    Distribution string  `json:"distribution"`
+}
+
+type Store struct {
+    db *database.DB
+}
+```
+
+### API
+
+| Method | Signature | Notes |
+|--------|-----------|-------|
+| RecordMetrics | `RecordMetrics(experimentID string, metrics []Metric) error` | Batch insert in transaction, validates inputs |
+| QueryMetrics | `QueryMetrics(experimentID, name string, startStep, endStep int64) ([]Metric, error)` | experimentID required, name/step range optional, ASC by step |
+| RecordRewardSignals | `RecordRewardSignals(experimentID string, signals []RewardSignal) error` | Batch insert in transaction, validates inputs |
+| QueryRewardSignals | `QueryRewardSignals(experimentID, component string, startStep, endStep int64) ([]RewardSignal, error)` | experimentID required, component/step range optional, ASC by step |
+
+### Design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Single store | Both tables in one `metrics.Store` | Closely related per-step experiment data |
+| Batch insert | Transaction-wrapped multi-row insert | Training steps emit multiple metrics at once |
+| Query filtering | experiment + name/component + step range | Covers chart and detail view use cases |
+| experimentID required | Always required on queries | Prevents full-table scans |
+
+### Test plan (14 tests)
+
+RecordMetrics (4): Batch insert success, empty experimentID error, empty metrics slice error, FK violation error.
+QueryMetrics (4): Returns all for experiment, filter by name, filter by step range, no matches returns empty slice.
+RecordRewardSignals (3): Batch insert with distribution JSON, empty experimentID error, empty signals slice error.
+QueryRewardSignals (3): Returns all for experiment, filter by component, filter by step range.

--- a/docs/plan/09-data-layer.md
+++ b/docs/plan/09-data-layer.md
@@ -229,7 +229,7 @@ Other (2): Unsubscribe stops delivery, cascade delete removes events.
 Domain package (`internal/metrics/`) providing:
 
 - **`store.go`** — `Metric` struct, `RewardSignal` struct, `Store` with RecordMetrics/QueryMetrics/RecordRewardSignals/QueryRewardSignals
-- **`store_test.go`** — 14 tests
+- **`store_test.go`** — 15 tests
 
 Wails integration:
 
@@ -280,9 +280,10 @@ type Store struct {
 | Query filtering | experiment + name/component + step range | Covers chart and detail view use cases |
 | experimentID required | Always required on queries | Prevents full-table scans |
 
-### Test plan (14 tests)
+### Test plan (15 tests)
 
 RecordMetrics (4): Batch insert success, empty experimentID error, empty metrics slice error, FK violation error.
 QueryMetrics (4): Returns all for experiment, filter by name, filter by step range, no matches returns empty slice.
 RecordRewardSignals (3): Batch insert with distribution JSON, empty experimentID error, empty signals slice error.
 QueryRewardSignals (3): Returns all for experiment, filter by component, filter by step range.
+Cascade delete (1): Deleting experiment cascades to both metrics and reward_signals.

--- a/docs/tdd/019-metrics-storage.md
+++ b/docs/tdd/019-metrics-storage.md
@@ -79,7 +79,7 @@ Full suite: 57 tests across 4 packages, all passing. Race detector clean.
 
 ### Files created
 - `internal/metrics/store.go` — Store with RecordMetrics, QueryMetrics, RecordRewardSignals, QueryRewardSignals
-- `internal/metrics/store_test.go` — 14 tests with isolated DB helper
+- `internal/metrics/store_test.go` — 15 tests with isolated DB helper
 - `metrics_api.go` — Wails API pass-through methods
 
 ### Files modified

--- a/docs/tdd/019-metrics-storage.md
+++ b/docs/tdd/019-metrics-storage.md
@@ -16,7 +16,7 @@ Implement metrics storage for experiment data. A single `metrics.Store` in `inte
 
 The `metrics` and `reward_signals` tables already exist (migration 001, cascade in 003). This issue adds the Go domain layer: a `Store` wrapping `*database.DB` with batch insert and filtered query methods, following the same patterns as `internal/experiment/` and `internal/event/`.
 
-## Test Plan (14 tests)
+## Test Plan (15 tests)
 
 ### RecordMetrics (4)
 1. `TestRecordMetrics` — Batch insert 3 metrics, verify all queryable
@@ -39,6 +39,9 @@ The `metrics` and `reward_signals` tables already exist (migration 001, cascade 
 12. `TestQueryRewardSignals_All` — Returns all signals for experiment, ASC by step
 13. `TestQueryRewardSignals_FilterByComponent` — Returns only matching component
 14. `TestQueryRewardSignals_FilterByStepRange` — Returns only signals in step range
+
+### Cascade Delete (1)
+15. `TestCascadeDelete` — Deleting experiment cascades to both metrics and reward_signals
 
 ## Failing Tests
 
@@ -65,11 +68,12 @@ All 14 tests failed during RED phase with stubs returning nil/no-op:
 === RUN   TestQueryRewardSignals_All                 --- PASS
 === RUN   TestQueryRewardSignals_FilterByComponent   --- PASS
 === RUN   TestQueryRewardSignals_FilterByStepRange   --- PASS
+=== RUN   TestCascadeDelete                          --- PASS
 PASS
-ok  github.com/kstruzzieri/flux-ml/internal/metrics  0.327s
+ok  github.com/kstruzzieri/flux-ml/internal/metrics  0.271s
 ```
 
-Full suite: 56 tests across 4 packages, all passing. Race detector clean.
+Full suite: 57 tests across 4 packages, all passing. Race detector clean.
 
 ## Implementation Summary
 

--- a/docs/tdd/019-metrics-storage.md
+++ b/docs/tdd/019-metrics-storage.md
@@ -1,0 +1,53 @@
+# TDD: Issue #19 — Metrics Storage
+
+## Issue Summary
+
+Implement metrics storage for experiment data. A single `metrics.Store` in `internal/metrics/` handles both the `metrics` and `reward_signals` tables with batch insert and filtered query operations.
+
+## Acceptance Criteria
+
+- [ ] Metrics stored efficiently (batch insert in transaction)
+- [ ] Queries perform well with indexes
+- [ ] Reward components tracked separately
+- [ ] Wails API bindings expose all four operations
+- [ ] All tests pass with race detector clean
+
+## Rationale
+
+The `metrics` and `reward_signals` tables already exist (migration 001, cascade in 003). This issue adds the Go domain layer: a `Store` wrapping `*database.DB` with batch insert and filtered query methods, following the same patterns as `internal/experiment/` and `internal/event/`.
+
+## Test Plan (14 tests)
+
+### RecordMetrics (4)
+1. `TestRecordMetrics` — Batch insert 3 metrics, verify all queryable
+2. `TestRecordMetrics_EmptyExperimentID` — Error for empty experiment ID
+3. `TestRecordMetrics_EmptySlice` — Error for empty metrics slice
+4. `TestRecordMetrics_ForeignKeyViolation` — Error for nonexistent experiment
+
+### QueryMetrics (4)
+5. `TestQueryMetrics_All` — Returns all metrics for experiment, ASC by step
+6. `TestQueryMetrics_FilterByName` — Returns only metrics matching name
+7. `TestQueryMetrics_FilterByStepRange` — Returns only metrics in step range
+8. `TestQueryMetrics_NoMatches` — Returns empty slice (not nil)
+
+### RecordRewardSignals (3)
+9. `TestRecordRewardSignals` — Batch insert with distribution JSON
+10. `TestRecordRewardSignals_EmptyExperimentID` — Error for empty experiment ID
+11. `TestRecordRewardSignals_EmptySlice` — Error for empty signals slice
+
+### QueryRewardSignals (3)
+12. `TestQueryRewardSignals_All` — Returns all signals for experiment, ASC by step
+13. `TestQueryRewardSignals_FilterByComponent` — Returns only matching component
+14. `TestQueryRewardSignals_FilterByStepRange` — Returns only signals in step range
+
+## Failing Tests
+
+> Tests written before implementation — see below for results.
+
+## Test Results
+
+> Pending implementation.
+
+## Implementation Summary
+
+> Pending implementation.

--- a/docs/tdd/019-metrics-storage.md
+++ b/docs/tdd/019-metrics-storage.md
@@ -16,7 +16,7 @@ Implement metrics storage for experiment data. A single `metrics.Store` in `inte
 
 The `metrics` and `reward_signals` tables already exist (migration 001, cascade in 003). This issue adds the Go domain layer: a `Store` wrapping `*database.DB` with batch insert and filtered query methods, following the same patterns as `internal/experiment/` and `internal/event/`.
 
-## Test Plan (15 tests)
+## Test Plan (17 tests)
 
 ### RecordMetrics (4)
 1. `TestRecordMetrics` — Batch insert 3 metrics, verify all queryable
@@ -24,24 +24,26 @@ The `metrics` and `reward_signals` tables already exist (migration 001, cascade 
 3. `TestRecordMetrics_EmptySlice` — Error for empty metrics slice
 4. `TestRecordMetrics_ForeignKeyViolation` — Error for nonexistent experiment
 
-### QueryMetrics (4)
-5. `TestQueryMetrics_All` — Returns all metrics for experiment, ASC by step
-6. `TestQueryMetrics_FilterByName` — Returns only metrics matching name
-7. `TestQueryMetrics_FilterByStepRange` — Returns only metrics in step range
-8. `TestQueryMetrics_NoMatches` — Returns empty slice (not nil)
+### QueryMetrics (5)
+5. `TestQueryMetrics_EmptyExperimentID` — Error for empty experiment ID
+6. `TestQueryMetrics_All` — Returns all metrics for experiment, ASC by step
+7. `TestQueryMetrics_FilterByName` — Returns only metrics matching name
+8. `TestQueryMetrics_FilterByStepRange` — Returns only metrics in step range
+9. `TestQueryMetrics_NoMatches` — Returns empty slice (not nil)
 
 ### RecordRewardSignals (3)
-9. `TestRecordRewardSignals` — Batch insert with distribution JSON
-10. `TestRecordRewardSignals_EmptyExperimentID` — Error for empty experiment ID
-11. `TestRecordRewardSignals_EmptySlice` — Error for empty signals slice
+10. `TestRecordRewardSignals` — Batch insert with distribution JSON
+11. `TestRecordRewardSignals_EmptyExperimentID` — Error for empty experiment ID
+12. `TestRecordRewardSignals_EmptySlice` — Error for empty signals slice
 
-### QueryRewardSignals (3)
-12. `TestQueryRewardSignals_All` — Returns all signals for experiment, ASC by step
-13. `TestQueryRewardSignals_FilterByComponent` — Returns only matching component
-14. `TestQueryRewardSignals_FilterByStepRange` — Returns only signals in step range
+### QueryRewardSignals (4)
+13. `TestQueryRewardSignals_EmptyExperimentID` — Error for empty experiment ID
+14. `TestQueryRewardSignals_All` — Returns all signals for experiment, ASC by step
+15. `TestQueryRewardSignals_FilterByComponent` — Returns only matching component
+16. `TestQueryRewardSignals_FilterByStepRange` — Returns only signals in step range
 
 ### Cascade Delete (1)
-15. `TestCascadeDelete` — Deleting experiment cascades to both metrics and reward_signals
+17. `TestCascadeDelete` — Deleting experiment cascades to both metrics and reward_signals
 
 ## Failing Tests
 
@@ -58,6 +60,7 @@ All 14 tests failed during RED phase with stubs returning nil/no-op:
 === RUN   TestRecordMetrics_EmptyExperimentID        --- PASS
 === RUN   TestRecordMetrics_EmptySlice               --- PASS
 === RUN   TestRecordMetrics_ForeignKeyViolation      --- PASS
+=== RUN   TestQueryMetrics_EmptyExperimentID         --- PASS
 === RUN   TestQueryMetrics_All                       --- PASS
 === RUN   TestQueryMetrics_FilterByName              --- PASS
 === RUN   TestQueryMetrics_FilterByStepRange         --- PASS
@@ -65,21 +68,22 @@ All 14 tests failed during RED phase with stubs returning nil/no-op:
 === RUN   TestRecordRewardSignals                    --- PASS
 === RUN   TestRecordRewardSignals_EmptyExperimentID  --- PASS
 === RUN   TestRecordRewardSignals_EmptySlice         --- PASS
+=== RUN   TestQueryRewardSignals_EmptyExperimentID   --- PASS
 === RUN   TestQueryRewardSignals_All                 --- PASS
 === RUN   TestQueryRewardSignals_FilterByComponent   --- PASS
 === RUN   TestQueryRewardSignals_FilterByStepRange   --- PASS
 === RUN   TestCascadeDelete                          --- PASS
 PASS
-ok  github.com/kstruzzieri/flux-ml/internal/metrics  0.271s
+ok  github.com/kstruzzieri/flux-ml/internal/metrics  3.389s
 ```
 
-Full suite: 57 tests across 4 packages, all passing. Race detector clean.
+Full suite: 59 tests across 4 packages, all passing. Race detector clean.
 
 ## Implementation Summary
 
 ### Files created
 - `internal/metrics/store.go` — Store with RecordMetrics, QueryMetrics, RecordRewardSignals, QueryRewardSignals
-- `internal/metrics/store_test.go` — 15 tests with isolated DB helper
+- `internal/metrics/store_test.go` — 17 tests with isolated DB helper
 - `metrics_api.go` — Wails API pass-through methods
 
 ### Files modified

--- a/docs/tdd/019-metrics-storage.md
+++ b/docs/tdd/019-metrics-storage.md
@@ -6,11 +6,11 @@ Implement metrics storage for experiment data. A single `metrics.Store` in `inte
 
 ## Acceptance Criteria
 
-- [ ] Metrics stored efficiently (batch insert in transaction)
-- [ ] Queries perform well with indexes
-- [ ] Reward components tracked separately
-- [ ] Wails API bindings expose all four operations
-- [ ] All tests pass with race detector clean
+- [x] Metrics stored efficiently (batch insert in transaction)
+- [x] Queries perform well with indexes
+- [x] Reward components tracked separately
+- [x] Wails API bindings expose all four operations
+- [x] All tests pass with race detector clean
 
 ## Rationale
 
@@ -42,12 +42,48 @@ The `metrics` and `reward_signals` tables already exist (migration 001, cascade 
 
 ## Failing Tests
 
-> Tests written before implementation — see below for results.
+All 14 tests failed during RED phase with stubs returning nil/no-op:
+- RecordMetrics tests: stubs returned nil (no error), queries returned 0 results
+- QueryMetrics tests: stubs returned nil slices
+- RecordRewardSignals tests: same pattern
+- QueryRewardSignals tests: same pattern
 
 ## Test Results
 
-> Pending implementation.
+```
+=== RUN   TestRecordMetrics                          --- PASS
+=== RUN   TestRecordMetrics_EmptyExperimentID        --- PASS
+=== RUN   TestRecordMetrics_EmptySlice               --- PASS
+=== RUN   TestRecordMetrics_ForeignKeyViolation      --- PASS
+=== RUN   TestQueryMetrics_All                       --- PASS
+=== RUN   TestQueryMetrics_FilterByName              --- PASS
+=== RUN   TestQueryMetrics_FilterByStepRange         --- PASS
+=== RUN   TestQueryMetrics_NoMatches                 --- PASS
+=== RUN   TestRecordRewardSignals                    --- PASS
+=== RUN   TestRecordRewardSignals_EmptyExperimentID  --- PASS
+=== RUN   TestRecordRewardSignals_EmptySlice         --- PASS
+=== RUN   TestQueryRewardSignals_All                 --- PASS
+=== RUN   TestQueryRewardSignals_FilterByComponent   --- PASS
+=== RUN   TestQueryRewardSignals_FilterByStepRange   --- PASS
+PASS
+ok  github.com/kstruzzieri/flux-ml/internal/metrics  0.327s
+```
+
+Full suite: 56 tests across 4 packages, all passing. Race detector clean.
 
 ## Implementation Summary
 
-> Pending implementation.
+### Files created
+- `internal/metrics/store.go` — Store with RecordMetrics, QueryMetrics, RecordRewardSignals, QueryRewardSignals
+- `internal/metrics/store_test.go` — 14 tests with isolated DB helper
+- `metrics_api.go` — Wails API pass-through methods
+
+### Files modified
+- `app.go` — Added `metrics *metrics.Store` field and initialization
+
+### Key decisions
+- Single Store handles both `metrics` and `reward_signals` tables
+- Batch inserts use `tx.Begin()`/`tx.Commit()` for atomicity with prepared statements
+- Query methods use dynamic WHERE with parameterized args (experimentID always required)
+- `sql.NullString` for nullable distribution JSON column
+- Empty distribution stored as NULL, empty string on read defaults to `""`

--- a/internal/metrics/store.go
+++ b/internal/metrics/store.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"github.com/kstruzzieri/flux-ml/internal/database"
+)
+
+// Metric represents a single training metric data point.
+type Metric struct {
+	ExperimentID string  `json:"experiment_id"`
+	Step         int64   `json:"step"`
+	Name         string  `json:"name"`
+	Value        float64 `json:"value"`
+	Timestamp    int64   `json:"timestamp"`
+}
+
+// RewardSignal represents a reward component measurement at a training step.
+type RewardSignal struct {
+	ExperimentID string  `json:"experiment_id"`
+	Step         int64   `json:"step"`
+	Component    string  `json:"component"`
+	Value        float64 `json:"value"`
+	Distribution string  `json:"distribution"`
+}
+
+// Store provides metrics and reward signal storage operations.
+type Store struct {
+	db *database.DB
+}
+
+// NewStore creates a new metrics store.
+func NewStore(db *database.DB) *Store {
+	return &Store{db: db}
+}
+
+// RecordMetrics inserts a batch of metrics in a single transaction.
+func (s *Store) RecordMetrics(experimentID string, metrics []Metric) error {
+	return nil
+}
+
+// QueryMetrics returns metrics matching the given filters, ordered by step ASC.
+func (s *Store) QueryMetrics(experimentID, name string, startStep, endStep int64) ([]Metric, error) {
+	return nil, nil
+}
+
+// RecordRewardSignals inserts a batch of reward signals in a single transaction.
+func (s *Store) RecordRewardSignals(experimentID string, signals []RewardSignal) error {
+	return nil
+}
+
+// QueryRewardSignals returns reward signals matching the given filters, ordered by step ASC.
+func (s *Store) QueryRewardSignals(experimentID, component string, startStep, endStep int64) ([]RewardSignal, error) {
+	return nil, nil
+}

--- a/internal/metrics/store.go
+++ b/internal/metrics/store.go
@@ -72,8 +72,13 @@ func (s *Store) RecordMetrics(experimentID string, metrics []Metric) error {
 }
 
 // QueryMetrics returns metrics matching the given filters, ordered by step ASC.
-// experimentID is required. name, startStep, endStep are optional (empty/zero = no filter).
+// experimentID is required. name is optional (empty = no filter).
+// startStep and endStep are optional (zero = no filter; step 0 is treated as "from the beginning"
+// which is equivalent since steps are non-negative).
 func (s *Store) QueryMetrics(experimentID, name string, startStep, endStep int64) ([]Metric, error) {
+	if experimentID == "" {
+		return nil, fmt.Errorf("experiment ID cannot be empty")
+	}
 	// Safety: conditions are hardcoded strings only; user values go through
 	// parameterized args. Do not interpolate user input into conditions.
 	query := `SELECT experiment_id, step, name, value, timestamp FROM metrics`
@@ -157,8 +162,13 @@ func (s *Store) RecordRewardSignals(experimentID string, signals []RewardSignal)
 }
 
 // QueryRewardSignals returns reward signals matching the given filters, ordered by step ASC.
-// experimentID is required. component, startStep, endStep are optional (empty/zero = no filter).
+// experimentID is required. component is optional (empty = no filter).
+// startStep and endStep are optional (zero = no filter; step 0 is treated as "from the beginning"
+// which is equivalent since steps are non-negative).
 func (s *Store) QueryRewardSignals(experimentID, component string, startStep, endStep int64) ([]RewardSignal, error) {
+	if experimentID == "" {
+		return nil, fmt.Errorf("experiment ID cannot be empty")
+	}
 	// Safety: conditions are hardcoded strings only; user values go through
 	// parameterized args. Do not interpolate user input into conditions.
 	query := `SELECT experiment_id, step, component, value, distribution FROM reward_signals`

--- a/internal/metrics/store.go
+++ b/internal/metrics/store.go
@@ -1,6 +1,10 @@
 package metrics
 
 import (
+	"database/sql"
+	"fmt"
+	"strings"
+
 	"github.com/kstruzzieri/flux-ml/internal/database"
 )
 
@@ -34,20 +38,170 @@ func NewStore(db *database.DB) *Store {
 
 // RecordMetrics inserts a batch of metrics in a single transaction.
 func (s *Store) RecordMetrics(experimentID string, metrics []Metric) error {
+	if experimentID == "" {
+		return fmt.Errorf("experiment ID cannot be empty")
+	}
+	if len(metrics) == 0 {
+		return fmt.Errorf("metrics slice cannot be empty")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(
+		`INSERT INTO metrics (experiment_id, step, name, value, timestamp) VALUES (?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("preparing statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, m := range metrics {
+		if _, err := stmt.Exec(experimentID, m.Step, m.Name, m.Value, m.Timestamp); err != nil {
+			return fmt.Errorf("inserting metric: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
+	}
 	return nil
 }
 
 // QueryMetrics returns metrics matching the given filters, ordered by step ASC.
+// experimentID is required. name, startStep, endStep are optional (empty/zero = no filter).
 func (s *Store) QueryMetrics(experimentID, name string, startStep, endStep int64) ([]Metric, error) {
-	return nil, nil
+	// Safety: conditions are hardcoded strings only; user values go through
+	// parameterized args. Do not interpolate user input into conditions.
+	query := `SELECT experiment_id, step, name, value, timestamp FROM metrics`
+	conditions := []string{"experiment_id = ?"}
+	args := []any{experimentID}
+
+	if name != "" {
+		conditions = append(conditions, "name = ?")
+		args = append(args, name)
+	}
+	if startStep > 0 {
+		conditions = append(conditions, "step >= ?")
+		args = append(args, startStep)
+	}
+	if endStep > 0 {
+		conditions = append(conditions, "step <= ?")
+		args = append(args, endStep)
+	}
+
+	query += " WHERE " + strings.Join(conditions, " AND ")
+	query += " ORDER BY step ASC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying metrics: %w", err)
+	}
+	defer rows.Close()
+
+	results := []Metric{}
+	for rows.Next() {
+		var m Metric
+		if err := rows.Scan(&m.ExperimentID, &m.Step, &m.Name, &m.Value, &m.Timestamp); err != nil {
+			return nil, fmt.Errorf("scanning metric: %w", err)
+		}
+		results = append(results, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating metrics: %w", err)
+	}
+
+	return results, nil
 }
 
 // RecordRewardSignals inserts a batch of reward signals in a single transaction.
 func (s *Store) RecordRewardSignals(experimentID string, signals []RewardSignal) error {
+	if experimentID == "" {
+		return fmt.Errorf("experiment ID cannot be empty")
+	}
+	if len(signals) == 0 {
+		return fmt.Errorf("signals slice cannot be empty")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(
+		`INSERT INTO reward_signals (experiment_id, step, component, value, distribution) VALUES (?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("preparing statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, sig := range signals {
+		var dist any
+		if sig.Distribution != "" {
+			dist = sig.Distribution
+		}
+		if _, err := stmt.Exec(experimentID, sig.Step, sig.Component, sig.Value, dist); err != nil {
+			return fmt.Errorf("inserting reward signal: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing transaction: %w", err)
+	}
 	return nil
 }
 
 // QueryRewardSignals returns reward signals matching the given filters, ordered by step ASC.
+// experimentID is required. component, startStep, endStep are optional (empty/zero = no filter).
 func (s *Store) QueryRewardSignals(experimentID, component string, startStep, endStep int64) ([]RewardSignal, error) {
-	return nil, nil
+	// Safety: conditions are hardcoded strings only; user values go through
+	// parameterized args. Do not interpolate user input into conditions.
+	query := `SELECT experiment_id, step, component, value, distribution FROM reward_signals`
+	conditions := []string{"experiment_id = ?"}
+	args := []any{experimentID}
+
+	if component != "" {
+		conditions = append(conditions, "component = ?")
+		args = append(args, component)
+	}
+	if startStep > 0 {
+		conditions = append(conditions, "step >= ?")
+		args = append(args, startStep)
+	}
+	if endStep > 0 {
+		conditions = append(conditions, "step <= ?")
+		args = append(args, endStep)
+	}
+
+	query += " WHERE " + strings.Join(conditions, " AND ")
+	query += " ORDER BY step ASC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying reward signals: %w", err)
+	}
+	defer rows.Close()
+
+	results := []RewardSignal{}
+	for rows.Next() {
+		var sig RewardSignal
+		var dist sql.NullString
+		if err := rows.Scan(&sig.ExperimentID, &sig.Step, &sig.Component, &sig.Value, &dist); err != nil {
+			return nil, fmt.Errorf("scanning reward signal: %w", err)
+		}
+		if dist.Valid {
+			sig.Distribution = dist.String
+		}
+		results = append(results, sig)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating reward signals: %w", err)
+	}
+
+	return results, nil
 }

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -110,11 +110,13 @@ func TestQueryMetrics_All(t *testing.T) {
 	store := newTestMetricsStore(t)
 	now := time.Now().Unix()
 
-	store.RecordMetrics(store.experimentID, []Metric{
+	if err := store.RecordMetrics(store.experimentID, []Metric{
 		{Step: 300, Name: "loss", Value: 0.1, Timestamp: now},
 		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
 		{Step: 200, Name: "reward", Value: 0.8, Timestamp: now},
-	})
+	}); err != nil {
+		t.Fatalf("RecordMetrics failed: %v", err)
+	}
 
 	results, err := store.QueryMetrics(store.experimentID, "", 0, 0)
 	if err != nil {
@@ -136,11 +138,13 @@ func TestQueryMetrics_FilterByName(t *testing.T) {
 	store := newTestMetricsStore(t)
 	now := time.Now().Unix()
 
-	store.RecordMetrics(store.experimentID, []Metric{
+	if err := store.RecordMetrics(store.experimentID, []Metric{
 		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
 		{Step: 100, Name: "reward", Value: 0.8, Timestamp: now},
 		{Step: 200, Name: "loss", Value: 0.3, Timestamp: now},
-	})
+	}); err != nil {
+		t.Fatalf("RecordMetrics failed: %v", err)
+	}
 
 	results, err := store.QueryMetrics(store.experimentID, "loss", 0, 0)
 	if err != nil {
@@ -160,12 +164,14 @@ func TestQueryMetrics_FilterByStepRange(t *testing.T) {
 	store := newTestMetricsStore(t)
 	now := time.Now().Unix()
 
-	store.RecordMetrics(store.experimentID, []Metric{
+	if err := store.RecordMetrics(store.experimentID, []Metric{
 		{Step: 50, Name: "loss", Value: 0.9, Timestamp: now},
 		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
 		{Step: 200, Name: "loss", Value: 0.3, Timestamp: now},
 		{Step: 300, Name: "loss", Value: 0.1, Timestamp: now},
-	})
+	}); err != nil {
+		t.Fatalf("RecordMetrics failed: %v", err)
+	}
 
 	results, err := store.QueryMetrics(store.experimentID, "", 100, 200)
 	if err != nil {
@@ -250,11 +256,13 @@ func TestRecordRewardSignals_EmptySlice(t *testing.T) {
 func TestQueryRewardSignals_All(t *testing.T) {
 	store := newTestMetricsStore(t)
 
-	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+	if err := store.RecordRewardSignals(store.experimentID, []RewardSignal{
 		{Step: 300, Component: "honesty", Value: 0.85},
 		{Step: 100, Component: "helpfulness", Value: 0.89},
 		{Step: 200, Component: "harmlessness", Value: 0.92},
-	})
+	}); err != nil {
+		t.Fatalf("RecordRewardSignals failed: %v", err)
+	}
 
 	results, err := store.QueryRewardSignals(store.experimentID, "", 0, 0)
 	if err != nil {
@@ -275,11 +283,13 @@ func TestQueryRewardSignals_All(t *testing.T) {
 func TestQueryRewardSignals_FilterByComponent(t *testing.T) {
 	store := newTestMetricsStore(t)
 
-	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+	if err := store.RecordRewardSignals(store.experimentID, []RewardSignal{
 		{Step: 100, Component: "helpfulness", Value: 0.89},
 		{Step: 100, Component: "harmlessness", Value: 0.92},
 		{Step: 200, Component: "helpfulness", Value: 0.91},
-	})
+	}); err != nil {
+		t.Fatalf("RecordRewardSignals failed: %v", err)
+	}
 
 	results, err := store.QueryRewardSignals(store.experimentID, "helpfulness", 0, 0)
 	if err != nil {
@@ -298,12 +308,14 @@ func TestQueryRewardSignals_FilterByComponent(t *testing.T) {
 func TestQueryRewardSignals_FilterByStepRange(t *testing.T) {
 	store := newTestMetricsStore(t)
 
-	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+	if err := store.RecordRewardSignals(store.experimentID, []RewardSignal{
 		{Step: 50, Component: "helpfulness", Value: 0.80},
 		{Step: 100, Component: "helpfulness", Value: 0.89},
 		{Step: 200, Component: "helpfulness", Value: 0.91},
 		{Step: 300, Component: "helpfulness", Value: 0.93},
-	})
+	}); err != nil {
+		t.Fatalf("RecordRewardSignals failed: %v", err)
+	}
 
 	results, err := store.QueryRewardSignals(store.experimentID, "", 100, 200)
 	if err != nil {
@@ -316,5 +328,47 @@ func TestQueryRewardSignals_FilterByStepRange(t *testing.T) {
 		if s.Step < 100 || s.Step > 200 {
 			t.Errorf("Step = %d, want in range [100, 200]", s.Step)
 		}
+	}
+}
+
+// --- Cascade delete test ---
+
+func TestCascadeDelete(t *testing.T) {
+	store := newTestMetricsStore(t)
+	now := time.Now().Unix()
+
+	// Insert metrics and reward signals
+	if err := store.RecordMetrics(store.experimentID, []Metric{
+		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
+	}); err != nil {
+		t.Fatalf("RecordMetrics failed: %v", err)
+	}
+	if err := store.RecordRewardSignals(store.experimentID, []RewardSignal{
+		{Step: 100, Component: "helpfulness", Value: 0.89},
+	}); err != nil {
+		t.Fatalf("RecordRewardSignals failed: %v", err)
+	}
+
+	// Delete the experiment directly
+	if _, err := store.db.Exec(`DELETE FROM experiments WHERE id = ?`, store.experimentID); err != nil {
+		t.Fatalf("Delete experiment failed: %v", err)
+	}
+
+	// Metrics should be cascade-deleted
+	metrics, err := store.QueryMetrics(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryMetrics after delete failed: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Errorf("expected 0 metrics after cascade delete, got %d", len(metrics))
+	}
+
+	// Reward signals should be cascade-deleted
+	signals, err := store.QueryRewardSignals(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryRewardSignals after delete failed: %v", err)
+	}
+	if len(signals) != 0 {
+		t.Errorf("expected 0 reward signals after cascade delete, got %d", len(signals))
 	}
 }

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -1,0 +1,320 @@
+package metrics
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kstruzzieri/flux-ml/internal/database"
+)
+
+// testMetricsStore wraps Store with test helpers.
+type testMetricsStore struct {
+	*Store
+	db           *database.DB
+	experimentID string
+}
+
+// newTestMetricsStore creates an isolated test database with a pre-existing experiment.
+func newTestMetricsStore(t *testing.T) *testMetricsStore {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+	db, err := database.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	expID := createTestExperiment(t, db, "test-experiment")
+	return &testMetricsStore{
+		Store:        NewStore(db),
+		db:           db,
+		experimentID: expID,
+	}
+}
+
+// createTestExperiment inserts an experiment directly and returns its ID.
+func createTestExperiment(t *testing.T, db *database.DB, name string) string {
+	t.Helper()
+	id := uuid.New().String()
+	now := time.Now().Unix()
+	_, err := db.Exec(
+		`INSERT INTO experiments (id, name, config, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id, name, `{}`, "pending", now, now,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test experiment: %v", err)
+	}
+	return id
+}
+
+// --- RecordMetrics tests ---
+
+func TestRecordMetrics(t *testing.T) {
+	store := newTestMetricsStore(t)
+	now := time.Now().Unix()
+
+	metrics := []Metric{
+		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
+		{Step: 100, Name: "reward", Value: 0.8, Timestamp: now},
+		{Step: 200, Name: "loss", Value: 0.3, Timestamp: now + 1},
+	}
+
+	err := store.RecordMetrics(store.experimentID, metrics)
+	if err != nil {
+		t.Fatalf("RecordMetrics failed: %v", err)
+	}
+
+	// Verify all metrics were inserted by querying them back
+	results, err := store.QueryMetrics(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryMetrics failed: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 metrics, got %d", len(results))
+	}
+}
+
+func TestRecordMetrics_EmptyExperimentID(t *testing.T) {
+	store := newTestMetricsStore(t)
+	err := store.RecordMetrics("", []Metric{{Step: 1, Name: "loss", Value: 0.5, Timestamp: 1}})
+	if err == nil {
+		t.Fatal("expected error for empty experiment ID, got nil")
+	}
+}
+
+func TestRecordMetrics_EmptySlice(t *testing.T) {
+	store := newTestMetricsStore(t)
+	err := store.RecordMetrics(store.experimentID, []Metric{})
+	if err == nil {
+		t.Fatal("expected error for empty metrics slice, got nil")
+	}
+}
+
+func TestRecordMetrics_ForeignKeyViolation(t *testing.T) {
+	store := newTestMetricsStore(t)
+	err := store.RecordMetrics("nonexistent-id", []Metric{
+		{Step: 1, Name: "loss", Value: 0.5, Timestamp: 1},
+	})
+	if err == nil {
+		t.Fatal("expected foreign key error, got nil")
+	}
+}
+
+// --- QueryMetrics tests ---
+
+func TestQueryMetrics_All(t *testing.T) {
+	store := newTestMetricsStore(t)
+	now := time.Now().Unix()
+
+	store.RecordMetrics(store.experimentID, []Metric{
+		{Step: 300, Name: "loss", Value: 0.1, Timestamp: now},
+		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
+		{Step: 200, Name: "reward", Value: 0.8, Timestamp: now},
+	})
+
+	results, err := store.QueryMetrics(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryMetrics failed: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 metrics, got %d", len(results))
+	}
+	// Verify ASC order by step
+	for i := 1; i < len(results); i++ {
+		if results[i].Step < results[i-1].Step {
+			t.Errorf("metrics not in step order: [%d].Step=%d < [%d].Step=%d",
+				i, results[i].Step, i-1, results[i-1].Step)
+		}
+	}
+}
+
+func TestQueryMetrics_FilterByName(t *testing.T) {
+	store := newTestMetricsStore(t)
+	now := time.Now().Unix()
+
+	store.RecordMetrics(store.experimentID, []Metric{
+		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
+		{Step: 100, Name: "reward", Value: 0.8, Timestamp: now},
+		{Step: 200, Name: "loss", Value: 0.3, Timestamp: now},
+	})
+
+	results, err := store.QueryMetrics(store.experimentID, "loss", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryMetrics failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 metrics named 'loss', got %d", len(results))
+	}
+	for _, m := range results {
+		if m.Name != "loss" {
+			t.Errorf("Name = %q, want %q", m.Name, "loss")
+		}
+	}
+}
+
+func TestQueryMetrics_FilterByStepRange(t *testing.T) {
+	store := newTestMetricsStore(t)
+	now := time.Now().Unix()
+
+	store.RecordMetrics(store.experimentID, []Metric{
+		{Step: 50, Name: "loss", Value: 0.9, Timestamp: now},
+		{Step: 100, Name: "loss", Value: 0.5, Timestamp: now},
+		{Step: 200, Name: "loss", Value: 0.3, Timestamp: now},
+		{Step: 300, Name: "loss", Value: 0.1, Timestamp: now},
+	})
+
+	results, err := store.QueryMetrics(store.experimentID, "", 100, 200)
+	if err != nil {
+		t.Fatalf("QueryMetrics failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 metrics in step range [100,200], got %d", len(results))
+	}
+	for _, m := range results {
+		if m.Step < 100 || m.Step > 200 {
+			t.Errorf("Step = %d, want in range [100, 200]", m.Step)
+		}
+	}
+}
+
+func TestQueryMetrics_NoMatches(t *testing.T) {
+	store := newTestMetricsStore(t)
+	results, err := store.QueryMetrics(store.experimentID, "nonexistent", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryMetrics failed: %v", err)
+	}
+	if results == nil {
+		t.Fatal("QueryMetrics returned nil, want empty slice")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 metrics, got %d", len(results))
+	}
+}
+
+// --- RecordRewardSignals tests ---
+
+func TestRecordRewardSignals(t *testing.T) {
+	store := newTestMetricsStore(t)
+
+	signals := []RewardSignal{
+		{Step: 100, Component: "helpfulness", Value: 0.89, Distribution: `{"buckets": [0.1, 0.2], "counts": [10, 20]}`},
+		{Step: 100, Component: "harmlessness", Value: 0.92, Distribution: ""},
+		{Step: 200, Component: "helpfulness", Value: 0.91, Distribution: `{"buckets": [0.2, 0.3], "counts": [15, 25]}`},
+	}
+
+	err := store.RecordRewardSignals(store.experimentID, signals)
+	if err != nil {
+		t.Fatalf("RecordRewardSignals failed: %v", err)
+	}
+
+	// Verify all signals were inserted
+	results, err := store.QueryRewardSignals(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryRewardSignals failed: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 signals, got %d", len(results))
+	}
+	// Verify distribution JSON preserved
+	for _, s := range results {
+		if s.Component == "helpfulness" && s.Step == 100 {
+			if s.Distribution != `{"buckets": [0.1, 0.2], "counts": [10, 20]}` {
+				t.Errorf("Distribution not preserved: %q", s.Distribution)
+			}
+		}
+	}
+}
+
+func TestRecordRewardSignals_EmptyExperimentID(t *testing.T) {
+	store := newTestMetricsStore(t)
+	err := store.RecordRewardSignals("", []RewardSignal{{Step: 1, Component: "helpfulness", Value: 0.5}})
+	if err == nil {
+		t.Fatal("expected error for empty experiment ID, got nil")
+	}
+}
+
+func TestRecordRewardSignals_EmptySlice(t *testing.T) {
+	store := newTestMetricsStore(t)
+	err := store.RecordRewardSignals(store.experimentID, []RewardSignal{})
+	if err == nil {
+		t.Fatal("expected error for empty signals slice, got nil")
+	}
+}
+
+// --- QueryRewardSignals tests ---
+
+func TestQueryRewardSignals_All(t *testing.T) {
+	store := newTestMetricsStore(t)
+
+	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+		{Step: 300, Component: "honesty", Value: 0.85},
+		{Step: 100, Component: "helpfulness", Value: 0.89},
+		{Step: 200, Component: "harmlessness", Value: 0.92},
+	})
+
+	results, err := store.QueryRewardSignals(store.experimentID, "", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryRewardSignals failed: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 signals, got %d", len(results))
+	}
+	// Verify ASC order by step
+	for i := 1; i < len(results); i++ {
+		if results[i].Step < results[i-1].Step {
+			t.Errorf("signals not in step order: [%d].Step=%d < [%d].Step=%d",
+				i, results[i].Step, i-1, results[i-1].Step)
+		}
+	}
+}
+
+func TestQueryRewardSignals_FilterByComponent(t *testing.T) {
+	store := newTestMetricsStore(t)
+
+	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+		{Step: 100, Component: "helpfulness", Value: 0.89},
+		{Step: 100, Component: "harmlessness", Value: 0.92},
+		{Step: 200, Component: "helpfulness", Value: 0.91},
+	})
+
+	results, err := store.QueryRewardSignals(store.experimentID, "helpfulness", 0, 0)
+	if err != nil {
+		t.Fatalf("QueryRewardSignals failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 signals for 'helpfulness', got %d", len(results))
+	}
+	for _, s := range results {
+		if s.Component != "helpfulness" {
+			t.Errorf("Component = %q, want %q", s.Component, "helpfulness")
+		}
+	}
+}
+
+func TestQueryRewardSignals_FilterByStepRange(t *testing.T) {
+	store := newTestMetricsStore(t)
+
+	store.RecordRewardSignals(store.experimentID, []RewardSignal{
+		{Step: 50, Component: "helpfulness", Value: 0.80},
+		{Step: 100, Component: "helpfulness", Value: 0.89},
+		{Step: 200, Component: "helpfulness", Value: 0.91},
+		{Step: 300, Component: "helpfulness", Value: 0.93},
+	})
+
+	results, err := store.QueryRewardSignals(store.experimentID, "", 100, 200)
+	if err != nil {
+		t.Fatalf("QueryRewardSignals failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 signals in step range [100,200], got %d", len(results))
+	}
+	for _, s := range results {
+		if s.Step < 100 || s.Step > 200 {
+			t.Errorf("Step = %d, want in range [100, 200]", s.Step)
+		}
+	}
+}

--- a/internal/metrics/store_test.go
+++ b/internal/metrics/store_test.go
@@ -106,6 +106,14 @@ func TestRecordMetrics_ForeignKeyViolation(t *testing.T) {
 
 // --- QueryMetrics tests ---
 
+func TestQueryMetrics_EmptyExperimentID(t *testing.T) {
+	store := newTestMetricsStore(t)
+	_, err := store.QueryMetrics("", "", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for empty experiment ID, got nil")
+	}
+}
+
 func TestQueryMetrics_All(t *testing.T) {
 	store := newTestMetricsStore(t)
 	now := time.Now().Unix()
@@ -252,6 +260,14 @@ func TestRecordRewardSignals_EmptySlice(t *testing.T) {
 }
 
 // --- QueryRewardSignals tests ---
+
+func TestQueryRewardSignals_EmptyExperimentID(t *testing.T) {
+	store := newTestMetricsStore(t)
+	_, err := store.QueryRewardSignals("", "", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for empty experiment ID, got nil")
+	}
+}
 
 func TestQueryRewardSignals_All(t *testing.T) {
 	store := newTestMetricsStore(t)

--- a/metrics_api.go
+++ b/metrics_api.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/kstruzzieri/flux-ml/internal/metrics"
+)
+
+// RecordMetrics inserts a batch of training metrics for an experiment.
+func (a *App) RecordMetrics(experimentID string, m []metrics.Metric) error {
+	if a.metrics == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return a.metrics.RecordMetrics(experimentID, m)
+}
+
+// QueryMetrics returns metrics matching the given filters, ordered by step ASC.
+// name, startStep, and endStep are optional (empty/zero = no filter).
+func (a *App) QueryMetrics(experimentID, name string, startStep, endStep int64) ([]metrics.Metric, error) {
+	if a.metrics == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	return a.metrics.QueryMetrics(experimentID, name, startStep, endStep)
+}
+
+// RecordRewardSignals inserts a batch of reward signal measurements for an experiment.
+func (a *App) RecordRewardSignals(experimentID string, signals []metrics.RewardSignal) error {
+	if a.metrics == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	return a.metrics.RecordRewardSignals(experimentID, signals)
+}
+
+// QueryRewardSignals returns reward signals matching the given filters, ordered by step ASC.
+// component, startStep, and endStep are optional (empty/zero = no filter).
+func (a *App) QueryRewardSignals(experimentID, component string, startStep, endStep int64) ([]metrics.RewardSignal, error) {
+	if a.metrics == nil {
+		return nil, fmt.Errorf("database not initialized")
+	}
+	return a.metrics.QueryRewardSignals(experimentID, component, startStep, endStep)
+}


### PR DESCRIPTION
## Summary
- Add `internal/metrics/` package with `Store` handling both `metrics` and `reward_signals` tables
- Batch insert via transactions with prepared statements for `RecordMetrics` and `RecordRewardSignals`
- Filtered queries (`QueryMetrics`, `QueryRewardSignals`) with dynamic WHERE clauses (experiment + name/component + step range)
- Wails API bindings in `metrics_api.go` with nil-check guards
- 17 tests covering CRUD, validation, filtering, cascade deletes
- Updated README with Phase 2A completion and backend package tree

## Test plan
- [x] 17 metrics tests passing (batch insert, validation, filtering, cascade delete)
- [x] 59 total tests across 4 packages
- [x] Race detector clean
- [x] `go vet` clean

Generated with [Claude Code](https://claude.ai/code)