### PR TITLE
chore: add workflow orchestration config

### DIFF
--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -1,0 +1,52 @@
+## Workflow Orchestration
+
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately - don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update `.claude/tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+
+1. **Plan First**: Write plan to `.claude/tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review section to `.claude/tasks/todo.md`
+6. **Capture Lessons**: Update `.claude/tasks/lessons.md` after corrections
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage/
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/tasks/todo.md
 
 # FewWord scratch files
 .fewword/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,4 @@ Project-specific agents in `.claude/agents/`:
 - Branch naming: feature/<issue_#>_<issue_description>
 - Create a test document in docs/tdd for each feature/issue
 - Include the following sections (see existing examples in docs/tdd): issue summary, acceptance criteria, rationale, failing test, expected output, test summary, passing tests results, implementation summary
+- Reference .claude/workflow.md regarding workflow orchestration


### PR DESCRIPTION
## Summary
- Add `.claude/workflow.md` with workflow orchestration guidelines (plan mode, subagents, verification, elegance)
- Add `.claude/tasks/lessons.md` for persistent cross-session learning
- Add `.claude/tasks/todo.md` to `.gitignore` (session-ephemeral)
- Update `CLAUDE.md` to reference workflow.md

## Test plan
- [x] No code changes, config only

Generated with [Claude Code](https://claude.ai/code)