### PR TITLE
feat: upgrade to React 19, pin TypeScript ~5.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go&logoColor=white" alt="Go">
-  <img src="https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black" alt="React">
+  <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black" alt="React">
   <img src="https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white" alt="TypeScript">
   <img src="https://img.shields.io/badge/Wails-2-DF0000?logo=wails&logoColor=white" alt="Wails">
   <img src="https://img.shields.io/badge/SQLite-3-003B57?logo=sqlite&logoColor=white" alt="SQLite">
@@ -44,7 +44,7 @@ Flux is a lightweight, workspace-focused IDE designed specifically for machine l
 ## Tech Stack
 
 - **Framework**: [Wails v2](https://wails.io) - Go backend + React frontend
-- **Frontend**: React 18 + TypeScript + Vite
+- **Frontend**: React 19 + TypeScript + Vite
 - **Backend**: Go 1.23+
 - **Platforms**: macOS, Windows, Linux
 

--- a/docs/tdd/101-upgrade-frontend-deps.md
+++ b/docs/tdd/101-upgrade-frontend-deps.md
@@ -1,0 +1,81 @@
+# TDD: Issue #101 - Upgrade Frontend Dependencies
+
+## Issue Summary
+Upgrade core frontend dependencies to latest stable versions: React 18 → 19, pin TypeScript ~5.9.3, keep Vite 7 (v8 is beta only). Apply required React 19 code refactors.
+
+## Acceptance Criteria
+- [x] All 171+ frontend tests pass after upgrades
+- [x] `forwardRef` removed from icon components
+- [x] `JSX.Element` replaced with `React.JSX.Element`
+- [x] README badges updated to reflect new versions
+- [x] No new deprecation warnings in test output
+
+## Rationale
+React 19 brings ref-as-prop (eliminating `forwardRef` boilerplate), improved performance, and the foundation for future features like Server Components. TypeScript 5.9.3 is already the resolved version — pinning with `~` prevents unexpected minor version jumps. Vite 8 is still in beta (8.0.0-beta.13), so we stay on the stable Vite 7.3.1.
+
+## Dependency Changes
+
+| Package | Before | After |
+|---------|--------|-------|
+| `react` | ^18.3.1 (18.3.1) | ^19.2.4 (19.2.4) |
+| `react-dom` | ^18.3.1 (18.3.1) | ^19.2.4 (19.2.4) |
+| `@types/react` | ^18.3.18 | ^19.2.13 |
+| `@types/react-dom` | ^18.3.5 | ^19.2.3 |
+| `typescript` | ^5.7.3 (5.9.3) | ~5.9.3 (5.9.3) |
+| `vite` | ^7.3.1 | ^7.3.1 (unchanged) |
+| `@vitejs/plugin-react` | ^4.3.4 | ^4.3.4 (unchanged) |
+
+## Code Changes
+
+### Remove `forwardRef` wrappers
+React 19 passes `ref` as a regular prop, making `forwardRef` unnecessary.
+
+**createIcon.tsx** — `createIcon()` and `createFilledIcon()`:
+```typescript
+// Before (React 18)
+const Icon = forwardRef<SVGSVGElement, IconProps>(({ size, label, className, ...props }, ref) => { ... })
+
+// After (React 19)
+function Icon({ ref, size, label, className, ...props }: IconProps & { ref?: React.Ref<SVGSVGElement> }) { ... }
+```
+
+**FileIcon.tsx**:
+```typescript
+// Before (React 18)
+export const FileIcon = forwardRef<HTMLSpanElement, FileIconProps>(({ extension, ... }, ref) => { ... })
+
+// After (React 19)
+export function FileIcon({ ref, extension, ... }: FileIconProps & { ref?: React.Ref<HTMLSpanElement> }) { ... }
+```
+
+### Replace `JSX.Element` → `React.JSX.Element`
+React 19 removed the global `JSX` namespace.
+
+**Header.tsx** and **ActivityBar.tsx**:
+```typescript
+// Before
+const NAV_ITEMS: { id: ViewId; label: string; icon: JSX.Element }[] = [...]
+
+// After
+const NAV_ITEMS: { id: ViewId; label: string; icon: React.JSX.Element }[] = [...]
+```
+
+## Test Results
+
+### Passing Tests
+```
+Test Suites: 17 passed, 17 total
+Tests:       171 passed, 171 total
+Time:        6.505s
+```
+
+All 171 tests pass across 17 suites. No new deprecation warnings. Production build succeeds.
+
+## Implementation Summary
+1. Upgraded `react`/`react-dom` from 18.3.1 to 19.2.4
+2. Upgraded `@types/react` and `@types/react-dom` to v19
+3. Pinned `typescript` to `~5.9.3`
+4. Removed `forwardRef` from `createIcon.tsx` (2 functions) and `FileIcon.tsx` (1 component)
+5. Replaced `JSX.Element` with `React.JSX.Element` in `Header.tsx` and `ActivityBar.tsx`
+6. Updated README badge and tech stack text
+7. Kept Vite at 7.3.1 (v8 is beta only)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "devicons-react": "^1.5.0",
         "lucide-react": "^0.563.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -22,8 +22,8 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
-        "@types/react": "^18.3.18",
-        "@types/react-dom": "^18.3.5",
+        "@types/react": "^19.2.13",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
         "@typescript-eslint/parser": "^8.21.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -37,7 +37,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^16.2.7",
         "prettier": "^3.4.2",
-        "typescript": "^5.7.3",
+        "typescript": "~5.9.3",
         "typescript-eslint": "^8.54.0",
         "vite": "^7.3.1"
       }
@@ -2820,32 +2820,24 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "version": "19.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
+      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -7942,6 +7934,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8381,6 +8374,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9220,28 +9214,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-is": {
@@ -9527,13 +9517,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "devicons-react": "^1.5.0",
     "lucide-react": "^0.563.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -31,8 +31,8 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
     "@typescript-eslint/parser": "^8.21.0",
     "@vitejs/plugin-react": "^4.3.4",
@@ -46,7 +46,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.4.2",
-    "typescript": "^5.7.3",
+    "typescript": "~5.9.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^7.3.1"
   },

--- a/frontend/src/components/layout/ActivityBar.tsx
+++ b/frontend/src/components/layout/ActivityBar.tsx
@@ -8,7 +8,7 @@ import {
   SettingsIcon,
 } from '../ui/Icon'
 
-const ACTIVITY_ITEMS: { id: ViewId; label: string; icon: JSX.Element }[] = [
+const ACTIVITY_ITEMS: { id: ViewId; label: string; icon: React.JSX.Element }[] = [
   {
     id: 'experiments',
     label: 'Experiments',

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ interface HeaderProps {
   onCommandPalette?: () => void
 }
 
-const NAV_ITEMS: { id: ViewId; label: string; icon: JSX.Element }[] = [
+const NAV_ITEMS: { id: ViewId; label: string; icon: React.JSX.Element }[] = [
   {
     id: 'experiments',
     label: 'Experiments',

--- a/frontend/src/components/ui/Icon/FileIcon.tsx
+++ b/frontend/src/components/ui/Icon/FileIcon.tsx
@@ -1,4 +1,3 @@
-import { forwardRef } from 'react'
 import {
   PythonIcon,
   YamlIcon,
@@ -58,26 +57,27 @@ const EXTENSION_MAP: Record<string, ExtensionEntry> = {
  * Uses devicons-react for language icons and custom SVGs for generic files.
  * Falls back to GenericFileIcon for unknown extensions.
  */
-export const FileIcon = forwardRef<HTMLSpanElement, FileIconProps>(
-  ({ extension, className, 'data-testid': testId }, ref) => {
-    const entry = extension ? EXTENSION_MAP[extension.toLowerCase()] : undefined
+export function FileIcon({
+  ref,
+  extension,
+  className,
+  'data-testid': testId,
+}: FileIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
+  const entry = extension ? EXTENSION_MAP[extension.toLowerCase()] : undefined
 
-    if (!entry) {
-      return (
-        <span ref={ref} className={`icon--generic-file ${className || ''}`} data-testid={testId}>
-          <GenericFileIcon />
-        </span>
-      )
-    }
-
-    const { Component, className: iconClassName } = entry
-
+  if (!entry) {
     return (
-      <span ref={ref} className={`${iconClassName} ${className || ''}`} data-testid={testId}>
-        <Component size="100%" />
+      <span ref={ref} className={`icon--generic-file ${className || ''}`} data-testid={testId}>
+        <GenericFileIcon />
       </span>
     )
   }
-)
 
-FileIcon.displayName = 'FileIcon'
+  const { Component, className: iconClassName } = entry
+
+  return (
+    <span ref={ref} className={`${iconClassName} ${className || ''}`} data-testid={testId}>
+      <Component size="100%" />
+    </span>
+  )
+}

--- a/frontend/src/components/ui/Icon/createIcon.tsx
+++ b/frontend/src/components/ui/Icon/createIcon.tsx
@@ -1,4 +1,3 @@
-import { forwardRef } from 'react'
 import type { IconProps } from './types'
 import './Icon.css'
 
@@ -18,7 +17,13 @@ interface CreateIconOptions {
 export function createIcon(path: React.ReactNode, options: CreateIconOptions) {
   const { displayName, iconClass, viewBox = '0 0 24 24' } = options
 
-  const Icon = forwardRef<SVGSVGElement, IconProps>(({ size, label, className, ...props }, ref) => {
+  function Icon({
+    ref,
+    size,
+    label,
+    className,
+    ...props
+  }: IconProps & { ref?: React.Ref<SVGSVGElement> }) {
     const classes = [
       'icon',
       typeof size === 'string' && ['sm', 'md', 'lg'].includes(size) && `icon--${size}`,
@@ -48,7 +53,7 @@ export function createIcon(path: React.ReactNode, options: CreateIconOptions) {
         {path}
       </svg>
     )
-  })
+  }
 
   Icon.displayName = displayName
   return Icon
@@ -61,7 +66,13 @@ export function createIcon(path: React.ReactNode, options: CreateIconOptions) {
 export function createFilledIcon(path: React.ReactNode, options: CreateIconOptions) {
   const { displayName, iconClass, viewBox = '0 0 24 24' } = options
 
-  const Icon = forwardRef<SVGSVGElement, IconProps>(({ size, label, className, ...props }, ref) => {
+  function Icon({
+    ref,
+    size,
+    label,
+    className,
+    ...props
+  }: IconProps & { ref?: React.Ref<SVGSVGElement> }) {
     const classes = [
       'icon',
       typeof size === 'string' && ['sm', 'md', 'lg'].includes(size) && `icon--${size}`,
@@ -80,7 +91,7 @@ export function createFilledIcon(path: React.ReactNode, options: CreateIconOptio
         {path}
       </svg>
     )
-  })
+  }
 
   Icon.displayName = displayName
   return Icon


### PR DESCRIPTION
## Summary
- Upgrade `react`/`react-dom` from 18.3.1 to 19.2.4
- Upgrade `@types/react` and `@types/react-dom` to v19
- Pin `typescript` to `~5.9.3` (already resolved version)
- Remove `forwardRef` from `createIcon`, `createFilledIcon`, and `FileIcon` (React 19 passes ref as regular prop)
- Replace `JSX.Element` with `React.JSX.Element` in `Header` and `ActivityBar` (React 19 removed global JSX namespace)
- Update README badge and tech stack text to React 19
- Keep Vite at 7.3.1 (v8 is beta only)

## Test Plan
- [x] All 171 frontend tests pass (17 suites)
- [x] `tsc --noEmit` passes with zero errors
- [x] `npm run build` production build succeeds
- [x] No new deprecation warnings in test output
- [x] `forwardRef` fully removed from codebase
- [x] No remaining bare `JSX.Element` references

Closes #101

Generated with [Claude Code](https://claude.com/claude-code)