### PR TITLE
feat: experiment detail view with diagnostic metrics and reward hack detection (#26)

### DIFF
--- a/docs/plan/13-experiment-detail-view.md
+++ b/docs/plan/13-experiment-detail-view.md
@@ -1,0 +1,165 @@
+# Experiment Detail View Layout — Design Document
+
+**Issue:** #26
+**Date:** 2026-02-08
+**Status:** Approved
+
+## Problem
+
+When a researcher selects an experiment, the MainPanel shows a header with name/status but an empty dashboard area. Researchers need at-a-glance access to training health — core metrics, reward component balance, and trend information — without clicking through multiple dashboards.
+
+## Design Principles
+
+- **Vital signs, not raw numbers** — Surface health status alongside values. Color-coded borders indicate whether a metric is healthy, concerning, or critical.
+- **Reward component balance front-and-center** — Divergence between reward components is the most dangerous signal in RLHF training. Don't hide it behind a tab.
+- **2-second glance rule** — A researcher should answer "is anything off?" within 2 seconds of selecting an experiment.
+
+## Layout Structure
+
+Three vertical sections within MainPanel, scrolling together:
+
+### 1. Experiment Header (existing, enhanced)
+
+- Status dot + experiment name + duration + status (already built)
+- **New:** Step count display (e.g., "Step 12,400") — researchers orient by step number
+
+### 2. Metrics Grid (new)
+
+Responsive grid of metric cards:
+
+**Row 1 (4 cards):**
+| Loss | Reward | KL Divergence | Learning Rate |
+|------|--------|---------------|---------------|
+
+**Row 2:**
+| Reward Components (2-col span) |
+|--------------------------------|
+
+> **Note:** ML engineer review recommended replacing Learning Rate with Gradient Norm and adding Policy Entropy. These are deferred to #107 since the seed data and backend don't yet emit these metrics. The grid structure supports easy swapping once those metrics are available.
+
+### 3. Charts Area (new, placeholder)
+
+Tabbed area for future Phase 3 uPlot integration:
+- Tab bar: "Overview" | "Reward Components" | "Diagnostics"
+- Chart body: centered placeholder with icon and message
+
+> **Note:** Tab names follow ML engineer recommendation to organize by workflow ("routine check", "reward model health", "dig deeper") rather than individual metric names. Actual chart content deferred to Phase 3.
+
+## Metric Card Design
+
+Each card has consistent anatomy:
+
+```
+┌─ health border (left accent: green/amber/red/muted) ─┐
+│  LABEL          (uppercase, muted, 10px)              │
+│  0.2341         (mono font, 20px, primary color)      │
+│  ↓ 0.03         (trend arrow + delta, colored)         │
+└───────────────────────────────────────────────────────┘
+```
+
+### Health Thresholds
+
+Thresholds are stored as a configurable `HEALTH_THRESHOLDS` constant in `health.ts` — documented as defaults that will become user-configurable in Phase 4.
+
+| Metric | Green | Amber | Red |
+|--------|-------|-------|-----|
+| Loss | Decreasing (window avg) | Flat | Increasing |
+| Reward | Increasing (window avg) | Flat | Decreasing |
+| KL Divergence | Trend stable | Accelerating upward | Exponential runaway |
+| Learning Rate | No health coloring | — | — |
+
+**Trend computation:** Compare mean of last 10 downsampled sparkline points vs. previous 10 points (20-point window). This provides stable trend assessment from the existing 60-point LTTB data without additional queries. Avoids the noise of 2-point comparison.
+
+**Insufficient data state:** When an experiment has fewer data points than the trend window requires, health border shows muted (no color) — not a false green/amber/red.
+
+> **Note:** KL thresholds changed from absolute values (0.05/0.1) to trend-based per ML engineer review. Absolute KL values vary dramatically by training algorithm and KL coefficient. Cross-metric health logic (reward up + KL diverging = reward hacking) deferred to #105.
+
+### Reward Components Card
+
+Wider card spanning 2 grid columns:
+
+```
+┌─ health border ──────────────────────────────────┐
+│  REWARD COMPONENTS              Step 9,990        │
+│  Helpfulness    ████████████░░░░  0.82            │
+│  Harmlessness   ██████████░░░░░░  0.74            │
+│  Honesty        ███████████░░░░░  0.79            │
+└──────────────────────────────────────────────────┘
+```
+
+Health border turns amber when any component is >2x another **AND** the max-min spread exceeds 0.1 (avoids false alarms on near-zero values).
+
+Displays the step number the reward signal data corresponds to, since rewards and metrics may arrive at different steps.
+
+## Component Architecture
+
+```
+MainPanel (modified)
+├── ExperimentHeader (existing section, add step count)
+├── MetricsGrid (new)
+│   ├── MetricCard × 4 (reusable)
+│   └── RewardComponentsCard (specialized)
+└── ChartsArea (new)
+    ├── ChartTabs (tab navigation)
+    └── ChartPlaceholder (placeholder body)
+```
+
+## File Plan
+
+| File | Purpose |
+|------|---------|
+| `components/Experiments/MetricCard.tsx` | Single metric card with health border |
+| `components/Experiments/MetricCard.css` | Card styles |
+| `components/Experiments/RewardComponentsCard.tsx` | Reward components card with bars |
+| `components/Experiments/MetricsGrid.tsx` | Grid layout, fetches data |
+| `components/Experiments/ChartsArea.tsx` | Tabbed charts placeholder |
+| `components/Experiments/ChartsArea.css` | Charts area styles |
+| `components/layout/panels/MainPanel.tsx` | Modified to compose new components |
+| `styles/components/layout.css` | Additional grid/card CSS |
+| `utils/formatting.ts` | Extended for KL, LR formatting |
+| `utils/health.ts` | Trend computation and health thresholds |
+
+## Data Flow
+
+- `MainPanel` gets `selectedId` from `experimentStore`
+- `MetricsGrid` calls `metricsStore.fetchLatestMetrics(id)` and reads `latestMetrics[id]`
+- Trend arrows computed from `sparklineData[id]` using 20-point windowed average comparison
+- **Reward signals:** Subscribe to `rewards:recorded` Wails event in metricsStore (or extend with dedicated methods). Fetch latest reward signals via `QueryRewardSignals`. This ensures the RewardComponentsCard updates reactively.
+- No new store needed — existing metricsStore extended with reward signal support
+
+## Test Plan
+
+1. **MetricCard:** renders label/value/trend, correct health colors, handles null values, muted border for insufficient data
+2. **RewardComponentsCard:** renders 3 bars, proportional widths, divergence detection with min-spread guard, displays step number
+3. **MetricsGrid:** renders all cards, fetches on mount, handles loading/empty states
+4. **ChartsArea:** renders tabs, active tab toggles, placeholder content
+5. **MainPanel integration:** welcome screen without selection, full detail with selection, step count in header
+6. **Health utilities:** windowed trend computation, threshold evaluation, insufficient data handling
+
+## What We're NOT Building
+
+- Real chart rendering (Phase 3 — uPlot)
+- Configurable threshold UI (Phase 4 — alert engine)
+- Cross-metric health correlation (#105)
+- Server-side LTTB downsampling (#104)
+- Throughput metric (#106)
+- Gradient norm / policy entropy metrics (#107)
+- Live updating animations (handled by existing store event subscriptions)
+- Config display (already in InspectorPanel/ConfigPanel)
+
+## Expert Review Notes
+
+Design reviewed by ML engineer and MLOps engineer agents. Key findings incorporated:
+- Trend-based KL thresholds instead of absolute values
+- 20-point windowed trend computation instead of 2-point
+- `rewards:recorded` event subscription for live reward component updates
+- Step number display on RewardComponentsCard
+- Min-spread guard on reward component divergence detection
+- Insufficient data state for health borders
+- Chart tabs renamed to workflow-oriented names
+
+Deferred findings tracked as follow-up issues:
+- #104: Server-side LTTB downsampling for sparkline scalability
+- #105: Cross-metric health logic for reward hacking detection
+- #106: Throughput metric (steps/sec)
+- #107: Gradient norm and policy entropy metrics

--- a/docs/plan/13a-experiment-detail-view-implementation.md
+++ b/docs/plan/13a-experiment-detail-view-implementation.md
@@ -1,0 +1,1407 @@
+# Experiment Detail View Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the experiment detail view layout with metric cards, reward components display, and charts placeholder in the MainPanel when an experiment is selected.
+
+**Architecture:** Extend MainPanel with three new child components (MetricsGrid, RewardComponentsCard, ChartsArea). MetricsGrid fetches data from the existing metricsStore and a new reward signal fetch method. Health assessment uses windowed trend computation from sparkline data. All styling uses the existing CSS custom properties design system.
+
+**Tech Stack:** React 19, Zustand 5, TypeScript 5.9, Lucide React (icons), Jest + React Testing Library
+
+---
+
+### Task 1: Health Utilities (`utils/health.ts`)
+
+Pure functions with no UI dependencies. Build and test first since MetricCard and RewardComponentsCard depend on them.
+
+**Files:**
+- Create: `frontend/src/utils/health.ts`
+- Test: `frontend/src/__tests__/utils/health.test.ts`
+
+**Step 1: Write the failing tests**
+
+Create `frontend/src/__tests__/utils/health.test.ts`:
+
+```typescript
+import { computeTrend, assessHealth, assessRewardDivergence } from '@utils/health'
+import type { Point } from '@utils/downsample'
+
+describe('computeTrend', () => {
+  it('returns "insufficient" when data has fewer than 4 points', () => {
+    const data: Point[] = [
+      { step: 1, value: 1.0 },
+      { step: 2, value: 0.9 },
+    ]
+    expect(computeTrend(data)).toBe('insufficient')
+  })
+
+  it('returns "down" when recent average is lower than previous average', () => {
+    // First half high, second half low
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: i < 10 ? 2.0 : 1.0,
+    }))
+    expect(computeTrend(data)).toBe('down')
+  })
+
+  it('returns "up" when recent average is higher than previous average', () => {
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: i < 10 ? 1.0 : 2.0,
+    }))
+    expect(computeTrend(data)).toBe('up')
+  })
+
+  it('returns "flat" when averages are within 1% of each other', () => {
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: 1.0,
+    }))
+    expect(computeTrend(data)).toBe('flat')
+  })
+})
+
+describe('assessHealth', () => {
+  it('returns "healthy" for decreasing loss', () => {
+    expect(assessHealth('loss', 'down')).toBe('healthy')
+  })
+
+  it('returns "warning" for flat loss', () => {
+    expect(assessHealth('loss', 'flat')).toBe('warning')
+  })
+
+  it('returns "critical" for increasing loss', () => {
+    expect(assessHealth('loss', 'up')).toBe('critical')
+  })
+
+  it('returns "healthy" for increasing reward', () => {
+    expect(assessHealth('reward', 'up')).toBe('healthy')
+  })
+
+  it('returns "critical" for decreasing reward', () => {
+    expect(assessHealth('reward', 'down')).toBe('critical')
+  })
+
+  it('returns "healthy" for stable kl', () => {
+    expect(assessHealth('kl', 'flat')).toBe('healthy')
+  })
+
+  it('returns "warning" for increasing kl', () => {
+    expect(assessHealth('kl', 'up')).toBe('warning')
+  })
+
+  it('returns "none" for insufficient data', () => {
+    expect(assessHealth('loss', 'insufficient')).toBe('none')
+  })
+
+  it('returns "none" for metrics without health rules (e.g., learning_rate)', () => {
+    expect(assessHealth('learning_rate', 'up')).toBe('none')
+  })
+})
+
+describe('assessRewardDivergence', () => {
+  it('returns "none" when components array is empty', () => {
+    expect(assessRewardDivergence([])).toBe('none')
+  })
+
+  it('returns "healthy" when components are balanced', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.8 },
+      { name: 'harmlessness', value: 0.7 },
+      { name: 'honesty', value: 0.75 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('healthy')
+  })
+
+  it('returns "warning" when one component is >2x another AND spread > 0.1', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.8 },
+      { name: 'harmlessness', value: 0.3 },
+      { name: 'honesty', value: 0.7 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('warning')
+  })
+
+  it('returns "healthy" when ratio exceeds 2x but spread is under 0.1', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.06 },
+      { name: 'harmlessness', value: 0.02 },
+      { name: 'honesty', value: 0.05 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('healthy')
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='health.test' --verbose`
+Expected: FAIL — module `@utils/health` not found
+
+**Step 3: Write the implementation**
+
+Create `frontend/src/utils/health.ts`:
+
+```typescript
+import type { Point } from '@utils/downsample'
+
+export type Trend = 'up' | 'down' | 'flat' | 'insufficient'
+export type HealthStatus = 'healthy' | 'warning' | 'critical' | 'none'
+
+const FLAT_THRESHOLD = 0.01 // 1% relative change = "flat"
+const MIN_POINTS = 4 // minimum data points for trend computation
+
+/**
+ * Computes trend direction from sparkline data using windowed average comparison.
+ * Splits the data in half and compares the mean of each half.
+ * Returns 'insufficient' if not enough data points.
+ */
+export function computeTrend(data: Point[]): Trend {
+  if (data.length < MIN_POINTS) return 'insufficient'
+
+  const mid = Math.floor(data.length / 2)
+  const prevSlice = data.slice(0, mid)
+  const recentSlice = data.slice(mid)
+
+  const prevAvg = prevSlice.reduce((s, p) => s + p.value, 0) / prevSlice.length
+  const recentAvg = recentSlice.reduce((s, p) => s + p.value, 0) / recentSlice.length
+
+  // Avoid division by zero — use absolute difference for near-zero values
+  const denom = Math.abs(prevAvg) > 1e-10 ? Math.abs(prevAvg) : 1
+  const relativeChange = (recentAvg - prevAvg) / denom
+
+  if (Math.abs(relativeChange) <= FLAT_THRESHOLD) return 'flat'
+  return relativeChange > 0 ? 'up' : 'down'
+}
+
+type HealthRule = Record<Exclude<Trend, 'insufficient'>, HealthStatus>
+
+const HEALTH_RULES: Record<string, HealthRule> = {
+  loss: { down: 'healthy', flat: 'warning', up: 'critical' },
+  reward: { up: 'healthy', flat: 'warning', down: 'critical' },
+  kl: { flat: 'healthy', up: 'warning', down: 'healthy' },
+}
+
+/**
+ * Assesses health status for a given metric based on its trend.
+ * Returns 'none' for insufficient data or metrics without health rules.
+ */
+export function assessHealth(metricName: string, trend: Trend): HealthStatus {
+  if (trend === 'insufficient') return 'none'
+  const rule = HEALTH_RULES[metricName]
+  if (!rule) return 'none'
+  return rule[trend]
+}
+
+interface RewardComponent {
+  name: string
+  value: number
+}
+
+const DIVERGENCE_RATIO = 2.0
+const DIVERGENCE_MIN_SPREAD = 0.1
+
+/**
+ * Assesses whether reward components are diverging.
+ * Returns 'warning' when any component is >2x another AND spread > 0.1.
+ */
+export function assessRewardDivergence(components: RewardComponent[]): HealthStatus {
+  if (components.length === 0) return 'none'
+
+  const values = components.map((c) => c.value)
+  const max = Math.max(...values)
+  const min = Math.min(...values)
+
+  if (max - min < DIVERGENCE_MIN_SPREAD) return 'healthy'
+  if (min > 0 && max / min > DIVERGENCE_RATIO) return 'warning'
+  if (min <= 0 && max - min > DIVERGENCE_MIN_SPREAD) return 'warning'
+
+  return 'healthy'
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='health.test' --verbose`
+Expected: All 12 tests PASS
+
+**Step 5: Commit**
+
+```
+feat: add health utility functions for metric trend and divergence assessment (#26)
+```
+
+---
+
+### Task 2: Extend formatting utilities
+
+**Files:**
+- Modify: `frontend/src/utils/formatting.ts`
+- Modify: `frontend/src/__tests__/utils/formatting.test.ts`
+
+**Step 1: Write the failing tests**
+
+Append to `frontend/src/__tests__/utils/formatting.test.ts`:
+
+```typescript
+// Add these tests to the existing file
+
+describe('formatMetricValue — extended metrics', () => {
+  it('formats kl with 6 decimal places', () => {
+    expect(formatMetricValue('kl', 0.0423567)).toBe('0.042357')
+  })
+
+  it('formats learning_rate in scientific notation', () => {
+    expect(formatMetricValue('learning_rate', 0.00003)).toBe('3.00e-5')
+  })
+})
+
+describe('formatStepCount', () => {
+  it('formats step count with comma separators', () => {
+    expect(formatStepCount(12400)).toBe('12,400')
+  })
+
+  it('formats small step counts without commas', () => {
+    expect(formatStepCount(50)).toBe('50')
+  })
+
+  it('formats zero', () => {
+    expect(formatStepCount(0)).toBe('0')
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='formatting.test' --verbose`
+Expected: FAIL — `formatStepCount` not defined, `kl` and `learning_rate` formatting unknown
+
+**Step 3: Implement**
+
+Modify `frontend/src/utils/formatting.ts`:
+
+Add to `METRIC_DECIMALS`:
+```typescript
+const METRIC_DECIMALS: Record<string, number> = {
+  loss: 4,
+  reward: 3,
+  kl: 6,
+}
+```
+
+Add `learning_rate` special case to `formatMetricValue`:
+```typescript
+export function formatMetricValue(name: string, value: number | null | undefined): string {
+  if (value == null) {
+    return '\u2014'
+  }
+  if (name === 'learning_rate') {
+    return value.toExponential(2)
+  }
+  const decimals = METRIC_DECIMALS[name] ?? 2
+  return value.toFixed(decimals)
+}
+```
+
+Add `formatStepCount`:
+```typescript
+export function formatStepCount(step: number): string {
+  return step.toLocaleString('en-US')
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='formatting.test' --verbose`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```
+feat: extend formatting utils for KL, learning rate, and step count (#26)
+```
+
+---
+
+### Task 3: Extend metricsStore with reward signal support
+
+**Files:**
+- Modify: `frontend/src/stores/metricsStore.ts`
+- Modify: `frontend/src/__tests__/stores/metricsStore.test.ts`
+
+**Step 1: Write the failing tests**
+
+Append to `frontend/src/__tests__/stores/metricsStore.test.ts`:
+
+```typescript
+import { RecordRewardSignals } from '../../__mocks__/wailsjs/go/main/App'
+
+describe('reward signal support', () => {
+  it('fetchLatestRewardSignals populates state for an experiment', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.82,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'helpfulness',
+        value: 0.85,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'harmlessness',
+        value: 0.74,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'honesty',
+        value: 0.79,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-1')
+    })
+
+    const signals = useMetricsStore.getState().latestRewardSignals['exp-1']
+    expect(signals).toBeDefined()
+    expect(signals).toHaveLength(3)
+    expect(signals.find((s: { component: string }) => s.component === 'helpfulness')?.value).toBe(0.85)
+    expect(signals.find((s: { component: string }) => s.component === 'harmlessness')?.value).toBe(0.74)
+  })
+
+  it('returns empty array for experiment with no reward signals', async () => {
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-none')
+    })
+
+    const signals = useMetricsStore.getState().latestRewardSignals['exp-none']
+    expect(signals).toEqual([])
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='metricsStore.test' --verbose`
+Expected: FAIL — `fetchLatestRewardSignals` not a function, `latestRewardSignals` undefined
+
+**Step 3: Implement**
+
+Modify `frontend/src/stores/metricsStore.ts`:
+
+Add to imports:
+```typescript
+import { GetLatestMetrics, QueryMetrics, QueryRewardSignals } from '../../wailsjs/go/main/App'
+```
+
+Add to state interface:
+```typescript
+interface LatestRewardSignal {
+  component: string
+  value: number
+  step: number
+}
+
+interface MetricsState {
+  // ... existing fields ...
+  latestRewardSignals: Record<string, LatestRewardSignal[]>
+  fetchLatestRewardSignals: (experimentId: string) => Promise<void>
+}
+```
+
+Add to store implementation:
+```typescript
+latestRewardSignals: {},
+
+fetchLatestRewardSignals: async (experimentId: string) => {
+  try {
+    const results = await QueryRewardSignals(experimentId, '', 0, 0)
+    // Group by component, keep highest step for each
+    const latestByComponent = new Map<string, { component: string; value: number; step: number }>()
+    for (const s of results) {
+      const existing = latestByComponent.get(s.component)
+      if (!existing || s.step > existing.step) {
+        latestByComponent.set(s.component, {
+          component: s.component,
+          value: s.value,
+          step: s.step,
+        })
+      }
+    }
+    set((state) => ({
+      latestRewardSignals: {
+        ...state.latestRewardSignals,
+        [experimentId]: [...latestByComponent.values()],
+      },
+    }))
+  } catch (err) {
+    console.error(`Failed to fetch reward signals for ${experimentId}:`, err)
+    set((state) => ({
+      latestRewardSignals: {
+        ...state.latestRewardSignals,
+        [experimentId]: [],
+      },
+    }))
+  }
+},
+```
+
+Add `rewards:recorded` event subscription inside `initialize()`:
+```typescript
+EventsOn('rewards:recorded', (data: { experimentId?: string }) => {
+  if (!data?.experimentId) return
+  const expId = data.experimentId
+  if (_debounceTimers[expId]) clearTimeout(_debounceTimers[expId])
+  _debounceTimers[expId] = setTimeout(() => {
+    delete _debounceTimers[expId]
+    get().fetchLatestMetrics(expId)
+    get().fetchSparklineData(expId)
+    get().fetchLatestRewardSignals(expId)
+  }, 200)
+})
+```
+
+Update `__resetMetricsStore` to clear `latestRewardSignals`:
+```typescript
+useMetricsStore.setState({ latestMetrics: {}, sparklineData: {}, latestRewardSignals: {} })
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='metricsStore.test' --verbose`
+Expected: All tests PASS (existing + new)
+
+**Step 5: Commit**
+
+```
+feat: add reward signal support and rewards:recorded subscription to metricsStore (#26)
+```
+
+---
+
+### Task 4: MetricCard component
+
+**Files:**
+- Create: `frontend/src/components/Experiments/MetricCard.tsx`
+- Create: `frontend/src/components/Experiments/MetricCard.css`
+- Test: `frontend/src/__tests__/components/Experiments/MetricCard.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Create `frontend/src/__tests__/components/Experiments/MetricCard.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react'
+import { MetricCard } from '@components/Experiments/MetricCard'
+
+describe('MetricCard', () => {
+  it('renders label and formatted value', () => {
+    render(<MetricCard label="Loss" value={0.2341} metricName="loss" trend="down" health="healthy" />)
+    expect(screen.getByText('LOSS')).toBeInTheDocument()
+    expect(screen.getByText('0.2341')).toBeInTheDocument()
+  })
+
+  it('renders em dash for null value', () => {
+    render(<MetricCard label="Loss" value={null} metricName="loss" trend="insufficient" health="none" />)
+    expect(screen.getByText('\u2014')).toBeInTheDocument()
+  })
+
+  it('renders down arrow for decreasing trend', () => {
+    render(<MetricCard label="Loss" value={0.5} metricName="loss" trend="down" health="healthy" />)
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('↓')
+  })
+
+  it('renders up arrow for increasing trend', () => {
+    render(<MetricCard label="Reward" value={0.8} metricName="reward" trend="up" health="healthy" />)
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('↑')
+  })
+
+  it('renders flat indicator for flat trend', () => {
+    render(<MetricCard label="KL" value={0.05} metricName="kl" trend="flat" health="healthy" />)
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('→')
+  })
+
+  it('does not render trend indicator when data is insufficient', () => {
+    render(<MetricCard label="Loss" value={0.5} metricName="loss" trend="insufficient" health="none" />)
+    expect(screen.queryByTestId('trend-indicator')).not.toBeInTheDocument()
+  })
+
+  it('applies healthy health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="down" health="healthy" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--healthy')
+  })
+
+  it('applies warning health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="flat" health="warning" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--warning')
+  })
+
+  it('applies critical health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="up" health="critical" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--critical')
+  })
+
+  it('has no health modifier class when health is none', () => {
+    const { container } = render(
+      <MetricCard label="LR" value={0.0003} metricName="learning_rate" trend="flat" health="none" />
+    )
+    const card = container.firstChild as HTMLElement
+    expect(card).toHaveClass('metric-card')
+    expect(card).not.toHaveClass('metric-card--healthy')
+    expect(card).not.toHaveClass('metric-card--warning')
+    expect(card).not.toHaveClass('metric-card--critical')
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='MetricCard.test' --verbose`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `frontend/src/components/Experiments/MetricCard.css`:
+
+```css
+.metric-card {
+  background: var(--color-bg-content);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  padding: 12px 14px;
+  border-left: 3px solid var(--color-border-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-card--healthy {
+  border-left-color: var(--color-success);
+}
+
+.metric-card--warning {
+  border-left-color: var(--color-warning);
+}
+
+.metric-card--critical {
+  border-left-color: var(--color-error);
+}
+
+.metric-card__label {
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.metric-card__value {
+  font-size: 20px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+
+.metric-card__trend {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.metric-card__trend--up {
+  color: var(--color-error);
+}
+
+.metric-card__trend--down {
+  color: var(--color-success);
+}
+
+.metric-card__trend--flat {
+  color: var(--color-text-muted);
+}
+```
+
+Create `frontend/src/components/Experiments/MetricCard.tsx`:
+
+```typescript
+import { formatMetricValue } from '@utils/formatting'
+import type { Trend, HealthStatus } from '@utils/health'
+import './MetricCard.css'
+
+interface MetricCardProps {
+  label: string
+  value: number | null | undefined
+  metricName: string
+  trend: Trend
+  health: HealthStatus
+}
+
+const TREND_ARROWS: Record<Exclude<Trend, 'insufficient'>, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+}
+
+export function MetricCard({ label, value, metricName, trend, health }: MetricCardProps) {
+  const healthClass = health !== 'none' ? `metric-card--${health}` : ''
+  const trendClass = trend !== 'insufficient' ? `metric-card__trend--${trend}` : ''
+
+  return (
+    <div className={`metric-card ${healthClass}`}>
+      <span className="metric-card__label">{label.toUpperCase()}</span>
+      <span className="metric-card__value">{formatMetricValue(metricName, value)}</span>
+      {trend !== 'insufficient' && (
+        <span className={`metric-card__trend ${trendClass}`} data-testid="trend-indicator">
+          {TREND_ARROWS[trend]}
+        </span>
+      )}
+    </div>
+  )
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='MetricCard.test' --verbose`
+Expected: All 10 tests PASS
+
+**Step 5: Commit**
+
+```
+feat: add MetricCard component with health borders and trend indicators (#26)
+```
+
+---
+
+### Task 5: RewardComponentsCard component
+
+**Files:**
+- Create: `frontend/src/components/Experiments/RewardComponentsCard.tsx`
+- Test: `frontend/src/__tests__/components/Experiments/RewardComponentsCard.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Create `frontend/src/__tests__/components/Experiments/RewardComponentsCard.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react'
+import { RewardComponentsCard } from '@components/Experiments/RewardComponentsCard'
+
+describe('RewardComponentsCard', () => {
+  const balancedComponents = [
+    { component: 'helpfulness', value: 0.82, step: 100 },
+    { component: 'harmlessness', value: 0.74, step: 100 },
+    { component: 'honesty', value: 0.79, step: 100 },
+  ]
+
+  it('renders all three component labels', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('Helpfulness')).toBeInTheDocument()
+    expect(screen.getByText('Harmlessness')).toBeInTheDocument()
+    expect(screen.getByText('Honesty')).toBeInTheDocument()
+  })
+
+  it('renders component values', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('0.82')).toBeInTheDocument()
+    expect(screen.getByText('0.74')).toBeInTheDocument()
+    expect(screen.getByText('0.79')).toBeInTheDocument()
+  })
+
+  it('displays step number', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('Step 100')).toBeInTheDocument()
+  })
+
+  it('applies healthy class when components are balanced', () => {
+    const { container } = render(<RewardComponentsCard components={balancedComponents} />)
+    expect(container.firstChild).toHaveClass('metric-card--healthy')
+  })
+
+  it('applies warning class when components diverge', () => {
+    const diverged = [
+      { component: 'helpfulness', value: 0.8, step: 100 },
+      { component: 'harmlessness', value: 0.3, step: 100 },
+      { component: 'honesty', value: 0.7, step: 100 },
+    ]
+    const { container } = render(<RewardComponentsCard components={diverged} />)
+    expect(container.firstChild).toHaveClass('metric-card--warning')
+  })
+
+  it('renders bar elements for each component', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    const bars = screen.getAllByTestId('reward-bar')
+    expect(bars).toHaveLength(3)
+  })
+
+  it('renders empty state when no components', () => {
+    render(<RewardComponentsCard components={[]} />)
+    expect(screen.getByText('No reward signal data')).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='RewardComponentsCard.test' --verbose`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `frontend/src/components/Experiments/RewardComponentsCard.tsx`:
+
+```typescript
+import { assessRewardDivergence } from '@utils/health'
+import './MetricCard.css'
+
+interface RewardComponentData {
+  component: string
+  value: number
+  step: number
+}
+
+interface RewardComponentsCardProps {
+  components: RewardComponentData[]
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function RewardComponentsCard({ components }: RewardComponentsCardProps) {
+  if (components.length === 0) {
+    return (
+      <div className="metric-card reward-components-card">
+        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="reward-components-card__empty">No reward signal data</span>
+      </div>
+    )
+  }
+
+  const health = assessRewardDivergence(
+    components.map((c) => ({ name: c.component, value: c.value }))
+  )
+  const healthClass = health !== 'none' ? `metric-card--${health}` : ''
+  const maxValue = Math.max(...components.map((c) => c.value), 1)
+  const step = Math.max(...components.map((c) => c.step))
+
+  return (
+    <div className={`metric-card reward-components-card ${healthClass}`}>
+      <div className="reward-components-card__header">
+        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="reward-components-card__step">Step {step.toLocaleString('en-US')}</span>
+      </div>
+      <div className="reward-components-card__bars">
+        {components.map((c) => (
+          <div key={c.component} className="reward-bar" data-testid="reward-bar">
+            <span className="reward-bar__label">{capitalize(c.component)}</span>
+            <div className="reward-bar__track">
+              <div
+                className="reward-bar__fill"
+                style={{ width: `${(c.value / maxValue) * 100}%` }}
+              />
+            </div>
+            <span className="reward-bar__value">{c.value.toFixed(2)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+Add reward components styles to `frontend/src/components/Experiments/MetricCard.css` (append):
+
+```css
+/* Reward Components Card */
+.reward-components-card {
+  grid-column: span 2;
+}
+
+.reward-components-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reward-components-card__step {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.reward-components-card__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.reward-components-card__empty {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  padding: 8px 0;
+}
+
+.reward-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reward-bar__label {
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.reward-bar__track {
+  flex: 1;
+  height: 6px;
+  background: var(--color-bg-panel);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.reward-bar__fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width var(--transition-normal);
+}
+
+.reward-bar__value {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  width: 36px;
+  text-align: right;
+  flex-shrink: 0;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='RewardComponentsCard.test' --verbose`
+Expected: All 7 tests PASS
+
+**Step 5: Commit**
+
+```
+feat: add RewardComponentsCard with divergence detection and bar visualization (#26)
+```
+
+---
+
+### Task 6: ChartsArea component (placeholder)
+
+**Files:**
+- Create: `frontend/src/components/Experiments/ChartsArea.tsx`
+- Create: `frontend/src/components/Experiments/ChartsArea.css`
+- Test: `frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Create `frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChartsArea } from '@components/Experiments/ChartsArea'
+
+describe('ChartsArea', () => {
+  it('renders three chart tabs', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Reward Components')).toBeInTheDocument()
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument()
+  })
+
+  it('has Overview tab active by default', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Overview').closest('button')).toHaveClass('chart-tab--active')
+  })
+
+  it('switches active tab on click', () => {
+    render(<ChartsArea />)
+    fireEvent.click(screen.getByText('Reward Components'))
+    expect(screen.getByText('Reward Components').closest('button')).toHaveClass('chart-tab--active')
+    expect(screen.getByText('Overview').closest('button')).not.toHaveClass('chart-tab--active')
+  })
+
+  it('shows placeholder content in chart body', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Chart visualization coming soon')).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='ChartsArea.test' --verbose`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `frontend/src/components/Experiments/ChartsArea.css`:
+
+```css
+.charts-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+  margin-top: var(--spacing-md);
+}
+
+.charts-area__tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.charts-area__placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-2xl);
+  color: var(--color-text-muted);
+}
+
+.charts-area__placeholder-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+
+.charts-area__placeholder-text {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.charts-area__placeholder-subtext {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+```
+
+Create `frontend/src/components/Experiments/ChartsArea.tsx`:
+
+```typescript
+import { useState } from 'react'
+import { LineChart } from 'lucide-react'
+import './ChartsArea.css'
+
+const TABS = ['Overview', 'Reward Components', 'Diagnostics'] as const
+
+export function ChartsArea() {
+  const [activeTab, setActiveTab] = useState<string>(TABS[0])
+
+  return (
+    <div className="charts-area">
+      <div className="charts-area__tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab}
+            className={`chart-tab ${activeTab === tab ? 'chart-tab--active' : ''}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="charts-area__placeholder">
+        <LineChart className="charts-area__placeholder-icon" />
+        <span className="charts-area__placeholder-text">Chart visualization coming soon</span>
+        <span className="charts-area__placeholder-subtext">uPlot integration in Phase 3</span>
+      </div>
+    </div>
+  )
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='ChartsArea.test' --verbose`
+Expected: All 4 tests PASS
+
+**Step 5: Commit**
+
+```
+feat: add ChartsArea placeholder with tabbed navigation (#26)
+```
+
+---
+
+### Task 7: MetricsGrid orchestrator component
+
+**Files:**
+- Create: `frontend/src/components/Experiments/MetricsGrid.tsx`
+- Test: `frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Create `frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx`:
+
+```typescript
+import { render, screen, act } from '@testing-library/react'
+import { MetricsGrid } from '@components/Experiments/MetricsGrid'
+import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
+import { __resetMockState, RecordMetrics, RecordRewardSignals } from '../../../__mocks__/wailsjs/go/main/App'
+import { metrics } from '../../../__mocks__/wailsjs/go/models'
+
+jest.mock('../../../../wailsjs/runtime/runtime', () => ({
+  EventsOn: jest.fn(),
+}))
+
+jest.mock('../../../../wailsjs/go/main/App', () =>
+  jest.requireActual('../../../__mocks__/wailsjs/go/main/App')
+)
+
+beforeEach(() => {
+  __resetMockState()
+  __resetMetricsStore()
+})
+
+describe('MetricsGrid', () => {
+  it('renders four metric cards', async () => {
+    await RecordMetrics('exp-1', [
+      new metrics.Metric({ experiment_id: 'exp-1', step: 1, name: 'loss', value: 2.5, timestamp: 1000 }),
+      new metrics.Metric({ experiment_id: 'exp-1', step: 1, name: 'reward', value: 0.3, timestamp: 1000 }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestMetrics('exp-1')
+      await useMetricsStore.getState().fetchSparklineData('exp-1')
+    })
+
+    render(<MetricsGrid experimentId="exp-1" />)
+
+    expect(screen.getByText('LOSS')).toBeInTheDocument()
+    expect(screen.getByText('REWARD')).toBeInTheDocument()
+    expect(screen.getByText('KL DIVERGENCE')).toBeInTheDocument()
+    expect(screen.getByText('LEARNING RATE')).toBeInTheDocument()
+  })
+
+  it('renders reward components card', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({ experiment_id: 'exp-1', step: 10, component: 'helpfulness', value: 0.8, distribution: '' }),
+      new metrics.RewardSignal({ experiment_id: 'exp-1', step: 10, component: 'harmlessness', value: 0.7, distribution: '' }),
+      new metrics.RewardSignal({ experiment_id: 'exp-1', step: 10, component: 'honesty', value: 0.75, distribution: '' }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-1')
+    })
+
+    render(<MetricsGrid experimentId="exp-1" />)
+
+    expect(screen.getByText('REWARD COMPONENTS')).toBeInTheDocument()
+    expect(screen.getByText('Helpfulness')).toBeInTheDocument()
+  })
+
+  it('shows em dash values when no metrics available', () => {
+    render(<MetricsGrid experimentId="exp-empty" />)
+    // All values should show em dash
+    const dashes = screen.getAllByText('\u2014')
+    expect(dashes.length).toBeGreaterThanOrEqual(4)
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='MetricsGrid.test' --verbose`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `frontend/src/components/Experiments/MetricsGrid.tsx`:
+
+```typescript
+import { useEffect } from 'react'
+import { useMetricsStore } from '@stores/metricsStore'
+import { computeTrend, assessHealth } from '@utils/health'
+import { MetricCard } from './MetricCard'
+import { RewardComponentsCard } from './RewardComponentsCard'
+
+interface MetricsGridProps {
+  experimentId: string
+}
+
+const METRIC_CARDS = [
+  { label: 'Loss', name: 'loss' },
+  { label: 'Reward', name: 'reward' },
+  { label: 'KL Divergence', name: 'kl' },
+  { label: 'Learning Rate', name: 'learning_rate' },
+] as const
+
+export function MetricsGrid({ experimentId }: MetricsGridProps) {
+  const latestMetrics = useMetricsStore((s) => s.latestMetrics[experimentId])
+  const sparklineData = useMetricsStore((s) => s.sparklineData[experimentId])
+  const latestRewardSignals = useMetricsStore((s) => s.latestRewardSignals[experimentId])
+  const fetchLatestMetrics = useMetricsStore((s) => s.fetchLatestMetrics)
+  const fetchSparklineData = useMetricsStore((s) => s.fetchSparklineData)
+  const fetchLatestRewardSignals = useMetricsStore((s) => s.fetchLatestRewardSignals)
+
+  useEffect(() => {
+    fetchLatestMetrics(experimentId)
+    fetchSparklineData(experimentId)
+    fetchLatestRewardSignals(experimentId)
+  }, [experimentId, fetchLatestMetrics, fetchSparklineData, fetchLatestRewardSignals])
+
+  return (
+    <div className="metrics-grid" data-testid="metrics-grid">
+      {METRIC_CARDS.map(({ label, name }) => {
+        const value = latestMetrics?.[name] ?? null
+        const points = sparklineData?.[name]
+        const trend = points ? computeTrend(points) : 'insufficient'
+        const health = assessHealth(name, trend)
+
+        return (
+          <MetricCard
+            key={name}
+            label={label}
+            value={value}
+            metricName={name}
+            trend={trend}
+            health={health}
+          />
+        )
+      })}
+      <RewardComponentsCard components={latestRewardSignals ?? []} />
+    </div>
+  )
+}
+```
+
+Add grid CSS to `frontend/src/styles/components/layout.css` (append before the scrollbar section):
+
+```css
+/* ========================================
+ * Metrics Grid
+ * ======================================== */
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='MetricsGrid.test' --verbose`
+Expected: All 3 tests PASS
+
+**Step 5: Commit**
+
+```
+feat: add MetricsGrid orchestrator with data fetching and health assessment (#26)
+```
+
+---
+
+### Task 8: Wire up MainPanel with new components
+
+**Files:**
+- Modify: `frontend/src/components/layout/panels/MainPanel.tsx`
+- Modify: `frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Append to `frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx`:
+
+```typescript
+// Add these tests to the existing describe block
+
+// Add these mocks at the top with the existing mocks
+jest.mock('../../../../wailsjs/go/main/App', () => ({
+  ListExperiments: jest.fn().mockResolvedValue([]),
+  GetLatestMetrics: jest.fn().mockResolvedValue([]),
+  QueryMetrics: jest.fn().mockResolvedValue([]),
+  QueryRewardSignals: jest.fn().mockResolvedValue([]),
+}))
+
+it('shows step count in header when experiment has metrics', async () => {
+  const exp = makeExperiment()
+  useExperimentStore.setState({
+    experiments: [exp],
+    selectedId: exp.id,
+  })
+
+  // Simulate metrics with step data
+  const { useMetricsStore } = await import('@stores/metricsStore')
+  useMetricsStore.setState({
+    latestMetrics: { [exp.id]: { loss: 0.5, reward: 0.8 } },
+    sparklineData: {},
+    latestRewardSignals: {},
+  })
+
+  render(<MainPanel />)
+  // Step count derived from metrics — checked in MetricsGrid
+  expect(screen.getByTestId('metrics-grid')).toBeInTheDocument()
+})
+
+it('shows charts area when experiment is selected', () => {
+  const exp = makeExperiment()
+  useExperimentStore.setState({
+    experiments: [exp],
+    selectedId: exp.id,
+  })
+  render(<MainPanel />)
+  expect(screen.getByText('Overview')).toBeInTheDocument()
+  expect(screen.getByText('Chart visualization coming soon')).toBeInTheDocument()
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && npx jest --testPathPattern='MainPanel.test' --verbose`
+Expected: FAIL — `metrics-grid` testid not found, 'Overview' not found
+
+**Step 3: Modify MainPanel**
+
+Modify `frontend/src/components/layout/panels/MainPanel.tsx`:
+
+```typescript
+import { useExperimentStore } from '@stores/experimentStore'
+import { useMetricsStore } from '@stores/metricsStore'
+import { StatusDot } from '@components/ui/StatusDot/StatusDot'
+import { formatDuration, formatStepCount, toExperimentStatus } from '@utils/formatting'
+import { MetricsGrid } from '@components/Experiments/MetricsGrid'
+import { ChartsArea } from '@components/Experiments/ChartsArea'
+
+// ... FluxBanner stays the same ...
+
+export function MainPanel() {
+  const selectedId = useExperimentStore((s) => s.selectedId)
+  const experiments = useExperimentStore((s) => s.experiments)
+  const selected = experiments.find((e) => e.id === selectedId)
+  const latestMetrics = useMetricsStore((s) => selectedId ? s.latestMetrics[selectedId] : undefined)
+
+  if (!selected) {
+    return (
+      <div className="panel panel--main">
+        <div className="main-content__welcome">
+          <FluxBanner />
+          <p className="main-content__tagline">The ML development environment</p>
+          <p className="main-content__hint">Select an experiment to view metrics</p>
+        </div>
+      </div>
+    )
+  }
+
+  const status = toExperimentStatus(selected.status)
+  const duration = formatDuration(selected.createdAt, selected.updatedAt, status)
+
+  // Derive step count from the highest step in any latest metric
+  // (The metrics store tracks latest values by name, but we need the step count
+  //  which we'll get from sparkline data — for now show from metric values if available)
+  const hasMetrics = latestMetrics && Object.keys(latestMetrics).length > 0
+
+  return (
+    <div className="panel panel--main">
+      <div className="experiment-header">
+        <StatusDot status={status} />
+        <div className="experiment-header__info">
+          <h1 className="experiment-header__name">{selected.name}</h1>
+          <div className="experiment-header__meta">
+            <span aria-label={`Duration: ${duration}`}>{duration}</span>
+            <span aria-label={`Status: ${status}`}>{status}</span>
+          </div>
+        </div>
+      </div>
+      <div className="experiment-header__dashboard">
+        <MetricsGrid experimentId={selected.id} />
+        <ChartsArea />
+      </div>
+    </div>
+  )
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && npx jest --testPathPattern='MainPanel.test' --verbose`
+Expected: All tests PASS (existing + new)
+
+**Step 5: Run full frontend test suite**
+
+Run: `cd frontend && npx jest --verbose`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```
+feat: wire MetricsGrid and ChartsArea into MainPanel for experiment detail view (#26)
+```
+
+---
+
+### Task 9: Create TDD documentation
+
+**Files:**
+- Create: `docs/tdd/026-experiment-detail-view.md`
+
+**Step 1: Create TDD document**
+
+Follow the project convention (see existing `docs/tdd/` examples). Include:
+- Issue summary
+- Acceptance criteria
+- Rationale
+- Test summary (all tests from tasks 1-8)
+- Implementation summary
+
+**Step 2: Run full test suite one final time**
+
+Run: `cd frontend && npx jest --verbose 2>&1 | tail -30`
+Expected: All tests pass, note total count
+
+**Step 3: Commit**
+
+```
+docs: add TDD document for experiment detail view (#26)
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (health.ts) ──┐
+Task 2 (formatting)──┤
+                      ├──> Task 4 (MetricCard) ──┐
+Task 3 (metricsStore)┤                           ├──> Task 7 (MetricsGrid) ──> Task 8 (MainPanel) ──> Task 9 (TDD doc)
+                      └──> Task 5 (RewardCard) ──┘
+                           Task 6 (ChartsArea) ───┘
+```
+
+Tasks 1, 2, 3 can run in parallel. Tasks 4, 5, 6 can run in parallel (after 1-3). Tasks 7-9 are sequential.

--- a/docs/tdd/026-experiment-detail-view.md
+++ b/docs/tdd/026-experiment-detail-view.md
@@ -1,0 +1,183 @@
+# TDD: Issue #26 - Experiment Detail View Layout
+
+## Issue Summary
+Build the experiment detail view layout in MainPanel when an experiment is selected. The view provides at-a-glance training health through metric cards with health-colored borders, reward component balance visualization, step count display, and a tabbed charts placeholder for Phase 3 uPlot integration. Design incorporates ML engineer and MLOps engineer recommendations for trend-based health thresholds, windowed trend computation, and workflow-oriented chart tabs.
+
+## Acceptance Criteria
+- [x] Health utilities: computeTrend (windowed average comparison), assessHealth (trend-based thresholds), assessRewardDivergence (ratio + min-spread guard)
+- [x] Formatting: KL with 6 decimals, learning rate in scientific notation, step count with locale formatting
+- [x] metricsStore: fetchLatestRewardSignals, rewards:recorded event subscription, latestRewardSignals state
+- [x] MetricCard: label, formatted value, trend arrow (up/down/flat), health border (healthy/warning/critical/none), muted for insufficient data
+- [x] RewardComponentsCard: horizontal bars with proportional fill, divergence detection, step number display, empty state
+- [x] ChartsArea: three workflow-oriented tabs (Overview, Reward Components, Diagnostics), placeholder content
+- [x] MetricsGrid: composes 4 MetricCards + RewardComponentsCard, fetches data on mount, derives trend and health from sparkline data
+- [x] MainPanel: renders MetricsGrid + ChartsArea in dashboard section, step count in header derived from sparkline data
+- [x] All existing tests continue to pass (232 total across 23 suites)
+
+## Rationale
+1. **Vital signs, not raw numbers** — Health-colored borders let researchers answer "is anything off?" within 2 seconds. Green/amber/red borders surface health status alongside values without requiring mental threshold comparison.
+2. **Trend-based KL thresholds** — Per ML engineer review, absolute KL values vary dramatically by training algorithm and KL coefficient. Trend stability (flat = healthy, up = warning) is universally meaningful.
+3. **Windowed trend computation** — Splits sparkline data in half and compares average of each half. More stable than 2-point comparison, leverages existing 60-point LTTB data without additional queries.
+4. **Reward component balance front-and-center** — Divergence between reward components is the most dangerous signal in RLHF training. The >2x ratio AND >0.1 min-spread guard prevents false alarms on near-zero values.
+5. **Step count in header** — Researchers orient by step number. Derived from sparkline data (no additional backend queries).
+6. **Workflow-oriented chart tabs** — Per ML engineer review, tabs named by workflow (Overview, Reward Components, Diagnostics) rather than individual metric names. Actual chart content deferred to Phase 3.
+7. **Insufficient data state** — Health borders show muted (no color) when not enough data points exist, preventing false green/amber/red on new experiments.
+
+## Failing Tests
+
+### Health Utilities (17 tests)
+
+#### computeTrend (4 tests)
+```typescript
+it('returns "insufficient" when data has fewer than 4 points', ...)
+it('returns "down" when recent average is lower than previous average', ...)
+it('returns "up" when recent average is higher than previous average', ...)
+it('returns "flat" when averages are within 1% of each other', ...)
+```
+
+#### assessHealth (9 tests)
+```typescript
+it('returns "healthy" for decreasing loss', ...)
+it('returns "warning" for flat loss', ...)
+it('returns "critical" for increasing loss', ...)
+it('returns "healthy" for increasing reward', ...)
+it('returns "critical" for decreasing reward', ...)
+it('returns "healthy" for stable kl', ...)
+it('returns "warning" for increasing kl', ...)
+it('returns "none" for insufficient data', ...)
+it('returns "none" for metrics without health rules', ...)
+```
+
+#### assessRewardDivergence (4 tests)
+```typescript
+it('returns "none" when components array is empty', ...)
+it('returns "healthy" when components are balanced', ...)
+it('returns "warning" when one component is >2x another AND spread > 0.1', ...)
+it('returns "healthy" when ratio exceeds 2x but spread is under 0.1', ...)
+```
+
+### Formatting Extensions (5 new tests)
+```typescript
+it('formats kl with 6 decimal places', ...)
+it('formats learning_rate in scientific notation', ...)
+it('formats step count with comma separators', ...)
+it('formats small step counts without commas', ...)
+it('formats zero', ...)
+```
+
+### metricsStore Reward Signals (2 new tests)
+```typescript
+it('fetchLatestRewardSignals populates state for an experiment', ...)
+it('returns empty array for experiment with no reward signals', ...)
+```
+
+### MetricCard (10 tests)
+```typescript
+it('renders label and formatted value', ...)
+it('renders em dash for null value', ...)
+it('renders down arrow for decreasing trend', ...)
+it('renders up arrow for increasing trend', ...)
+it('renders flat indicator for flat trend', ...)
+it('does not render trend indicator when data is insufficient', ...)
+it('applies healthy health class', ...)
+it('applies warning health class', ...)
+it('applies critical health class', ...)
+it('has no health modifier class when health is none', ...)
+```
+
+### RewardComponentsCard (7 tests)
+```typescript
+it('renders all three component labels', ...)
+it('renders component values', ...)
+it('displays step number', ...)
+it('applies healthy class when components are balanced', ...)
+it('applies warning class when components diverge', ...)
+it('renders bar elements for each component', ...)
+it('renders empty state when no components', ...)
+```
+
+### ChartsArea (4 tests)
+```typescript
+it('renders three chart tabs', ...)
+it('has Overview tab active by default', ...)
+it('switches active tab on click', ...)
+it('shows placeholder content in chart body', ...)
+```
+
+### MetricsGrid (3 tests)
+```typescript
+it('renders four metric cards', ...)
+it('renders reward components card', ...)
+it('shows em dash values when no metrics available', ...)
+```
+
+### MainPanel Integration (4 new tests)
+```typescript
+it('shows metrics grid when experiment is selected', ...)
+it('shows charts area when experiment is selected', ...)
+it('shows step count in header when sparkline data is available', ...)
+it('does not show step count when no sparkline data', ...)
+```
+
+## Expected Output
+All failing tests should fail with "module not found" or "function not defined" errors before implementation, then pass after implementation.
+
+## Test Summary
+
+| Suite | Tests | Status |
+|-------|-------|--------|
+| health.test.ts | 17 | PASS |
+| formatting.test.ts | 16 (11 existing + 5 new) | PASS |
+| metricsStore.test.ts | 8 (6 existing + 2 new) | PASS |
+| MetricCard.test.tsx | 10 | PASS |
+| RewardComponentsCard.test.tsx | 7 | PASS |
+| ChartsArea.test.tsx | 4 | PASS |
+| MetricsGrid.test.tsx | 3 | PASS |
+| MainPanel.test.tsx | 9 (5 existing + 4 new) | PASS |
+| **Total new tests** | **52** | **PASS** |
+| **Full suite** | **232 tests, 23 suites** | **ALL PASS** |
+
+## Passing Test Results
+```
+Test Suites: 23 passed, 23 total
+Tests:       232 passed, 232 total
+Snapshots:   0 total
+```
+
+## Implementation Summary
+
+### Files Created (8)
+| File | Purpose |
+|------|---------|
+| `frontend/src/utils/health.ts` | computeTrend, assessHealth, assessRewardDivergence |
+| `frontend/src/__tests__/utils/health.test.ts` | 17 health utility tests |
+| `frontend/src/components/Experiments/MetricCard.tsx` | Health-bordered metric card with trend arrow |
+| `frontend/src/components/Experiments/MetricCard.css` | Card styles + reward components card styles |
+| `frontend/src/components/Experiments/RewardComponentsCard.tsx` | Reward component bars with divergence detection |
+| `frontend/src/components/Experiments/ChartsArea.tsx` | Tabbed placeholder for Phase 3 uPlot |
+| `frontend/src/components/Experiments/ChartsArea.css` | Charts area styles |
+| `frontend/src/components/Experiments/MetricsGrid.tsx` | Grid orchestrator composing cards |
+
+### Files Modified (5)
+| File | Changes |
+|------|---------|
+| `frontend/src/utils/formatting.ts` | Added kl decimals, learning_rate exponential, formatStepCount |
+| `frontend/src/stores/metricsStore.ts` | Added latestRewardSignals, fetchLatestRewardSignals, rewards:recorded subscription |
+| `frontend/src/components/layout/panels/MainPanel.tsx` | Import MetricsGrid/ChartsArea, add step count, useLatestStep hook |
+| `frontend/src/styles/components/layout.css` | Added metrics-grid and experiment-header__step styles |
+| `frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx` | 4 new integration tests, expanded App mock |
+
+### ML Engineer Recommendations Incorporated
+1. Trend-based KL thresholds (not absolute values)
+2. Windowed trend computation (split-half average comparison)
+3. `rewards:recorded` event subscription for live updates
+4. Step number display on RewardComponentsCard
+5. Min-spread guard (0.1) on reward divergence detection
+6. Insufficient data state (muted health border)
+7. Workflow-oriented chart tab names
+
+### Deferred to Follow-up Issues
+- #104: Server-side LTTB downsampling for sparkline scalability
+- #105: Cross-metric health logic for reward hacking detection
+- #106: Throughput metric (steps/sec)
+- #107: Gradient norm and policy entropy metrics

--- a/docs/tdd/026-experiment-detail-view.md
+++ b/docs/tdd/026-experiment-detail-view.md
@@ -7,7 +7,7 @@ Build the experiment detail view layout in MainPanel when an experiment is selec
 - [x] Health utilities: computeTrend (windowed average comparison), assessHealth (trend-based thresholds), assessRewardDivergence (ratio + min-spread guard)
 - [x] Formatting: KL with 6 decimals, learning rate in scientific notation, step count with locale formatting
 - [x] metricsStore: fetchLatestRewardSignals, rewards:recorded event subscription, latestRewardSignals state
-- [x] MetricCard: label, formatted value, trend arrow (up/down/flat), health border (healthy/warning/critical/none), muted for insufficient data
+- [x] MetricCard: label, formatted value, trend arrow (up/down/flat), health border (healthy/warning/critical/none), muted for insufficient data, inline sparkline, trend percentage, subtitle
 - [x] RewardComponentsCard: horizontal bars with proportional fill, divergence detection, step number display, empty state
 - [x] ChartsArea: three workflow-oriented tabs (Overview, Reward Components, Diagnostics), placeholder content
 - [x] MetricsGrid: composes 4 MetricCards + RewardComponentsCard, fetches data on mount, derives trend and health from sparkline data
@@ -129,18 +129,18 @@ All failing tests should fail with "module not found" or "function not defined" 
 | health.test.ts | 19 | PASS |
 | formatting.test.ts | 16 (11 existing + 5 new) | PASS |
 | metricsStore.test.ts | 8 (6 existing + 2 new) | PASS |
-| MetricCard.test.tsx | 10 | PASS |
+| MetricCard.test.tsx | 16 (10 + 6 sparkline/subtitle) | PASS |
 | RewardComponentsCard.test.tsx | 7 | PASS |
 | ChartsArea.test.tsx | 4 | PASS |
 | MetricsGrid.test.tsx | 3 | PASS |
 | MainPanel.test.tsx | 9 (5 existing + 4 new) | PASS |
-| **Total new tests** | **54** | **PASS** |
-| **Full suite** | **234 tests, 23 suites** | **ALL PASS** |
+| **Total new tests** | **60** | **PASS** |
+| **Full suite** | **240 tests, 23 suites** | **ALL PASS** |
 
 ## Passing Test Results
 ```
 Test Suites: 23 passed, 23 total
-Tests:       234 passed, 234 total
+Tests:       240 passed, 240 total
 Snapshots:   0 total
 ```
 
@@ -151,7 +151,7 @@ Snapshots:   0 total
 |------|---------|
 | `frontend/src/utils/health.ts` | computeTrend, assessHealth, assessRewardDivergence |
 | `frontend/src/__tests__/utils/health.test.ts` | 17 health utility tests |
-| `frontend/src/components/Experiments/MetricCard.tsx` | Health-bordered metric card with trend arrow |
+| `frontend/src/components/Experiments/MetricCard.tsx` | Health-bordered metric card with trend arrow, inline sparkline, percentage, subtitle |
 | `frontend/src/components/Experiments/MetricCard.css` | Card styles + reward components card styles |
 | `frontend/src/components/Experiments/RewardComponentsCard.tsx` | Reward component bars with divergence detection |
 | `frontend/src/components/Experiments/ChartsArea.tsx` | Tabbed placeholder for Phase 3 uPlot |

--- a/docs/tdd/026-experiment-detail-view.md
+++ b/docs/tdd/026-experiment-detail-view.md
@@ -126,7 +126,7 @@ All failing tests should fail with "module not found" or "function not defined" 
 
 | Suite | Tests | Status |
 |-------|-------|--------|
-| health.test.ts | 17 | PASS |
+| health.test.ts | 19 | PASS |
 | formatting.test.ts | 16 (11 existing + 5 new) | PASS |
 | metricsStore.test.ts | 8 (6 existing + 2 new) | PASS |
 | MetricCard.test.tsx | 10 | PASS |
@@ -134,13 +134,13 @@ All failing tests should fail with "module not found" or "function not defined" 
 | ChartsArea.test.tsx | 4 | PASS |
 | MetricsGrid.test.tsx | 3 | PASS |
 | MainPanel.test.tsx | 9 (5 existing + 4 new) | PASS |
-| **Total new tests** | **52** | **PASS** |
-| **Full suite** | **232 tests, 23 suites** | **ALL PASS** |
+| **Total new tests** | **54** | **PASS** |
+| **Full suite** | **234 tests, 23 suites** | **ALL PASS** |
 
 ## Passing Test Results
 ```
 Test Suites: 23 passed, 23 total
-Tests:       232 passed, 232 total
+Tests:       234 passed, 234 total
 Snapshots:   0 total
 ```
 

--- a/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChartsArea } from '@components/Experiments/ChartsArea'
+
+describe('ChartsArea', () => {
+  it('renders three chart tabs', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Reward Components')).toBeInTheDocument()
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument()
+  })
+
+  it('has Overview tab active by default', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Overview').closest('button')).toHaveClass('chart-tab--active')
+  })
+
+  it('switches active tab on click', () => {
+    render(<ChartsArea />)
+    fireEvent.click(screen.getByText('Reward Components'))
+    expect(screen.getByText('Reward Components').closest('button')).toHaveClass('chart-tab--active')
+    expect(screen.getByText('Overview').closest('button')).not.toHaveClass('chart-tab--active')
+  })
+
+  it('shows placeholder content in chart body', () => {
+    render(<ChartsArea />)
+    expect(screen.getByText('Chart visualization coming soon')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
@@ -11,14 +11,18 @@ describe('ChartsArea', () => {
 
   it('has Overview tab active by default', () => {
     render(<ChartsArea />)
-    expect(screen.getByText('Overview').closest('button')).toHaveClass('chart-tab--active')
+    expect(screen.getByText('Overview').closest('button')).toHaveClass('charts-area__tab--active')
   })
 
   it('switches active tab on click', () => {
     render(<ChartsArea />)
     fireEvent.click(screen.getByText('Reward Components'))
-    expect(screen.getByText('Reward Components').closest('button')).toHaveClass('chart-tab--active')
-    expect(screen.getByText('Overview').closest('button')).not.toHaveClass('chart-tab--active')
+    expect(screen.getByText('Reward Components').closest('button')).toHaveClass(
+      'charts-area__tab--active'
+    )
+    expect(screen.getByText('Overview').closest('button')).not.toHaveClass(
+      'charts-area__tab--active'
+    )
   })
 
   it('shows placeholder content in chart body', () => {

--- a/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { MetricCard } from '@components/Experiments/MetricCard'
+
+describe('MetricCard', () => {
+  it('renders label and formatted value', () => {
+    render(
+      <MetricCard label="Loss" value={0.2341} metricName="loss" trend="down" health="healthy" />
+    )
+    expect(screen.getByText('LOSS')).toBeInTheDocument()
+    expect(screen.getByText('0.2341')).toBeInTheDocument()
+  })
+
+  it('renders em dash for null value', () => {
+    render(
+      <MetricCard label="Loss" value={null} metricName="loss" trend="insufficient" health="none" />
+    )
+    expect(screen.getByText('\u2014')).toBeInTheDocument()
+  })
+
+  it('renders down arrow for decreasing trend', () => {
+    render(<MetricCard label="Loss" value={0.5} metricName="loss" trend="down" health="healthy" />)
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('↓')
+  })
+
+  it('renders up arrow for increasing trend', () => {
+    render(
+      <MetricCard label="Reward" value={0.8} metricName="reward" trend="up" health="healthy" />
+    )
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('↑')
+  })
+
+  it('renders flat indicator for flat trend', () => {
+    render(<MetricCard label="KL" value={0.05} metricName="kl" trend="flat" health="healthy" />)
+    expect(screen.getByTestId('trend-indicator')).toHaveTextContent('→')
+  })
+
+  it('does not render trend indicator when data is insufficient', () => {
+    render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="insufficient" health="none" />
+    )
+    expect(screen.queryByTestId('trend-indicator')).not.toBeInTheDocument()
+  })
+
+  it('applies healthy health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="down" health="healthy" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--healthy')
+  })
+
+  it('applies warning health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="flat" health="warning" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--warning')
+  })
+
+  it('applies critical health class', () => {
+    const { container } = render(
+      <MetricCard label="Loss" value={0.5} metricName="loss" trend="up" health="critical" />
+    )
+    expect(container.firstChild).toHaveClass('metric-card--critical')
+  })
+
+  it('has no health modifier class when health is none', () => {
+    const { container } = render(
+      <MetricCard label="LR" value={0.0003} metricName="learning_rate" trend="flat" health="none" />
+    )
+    const card = container.firstChild as HTMLElement
+    expect(card).toHaveClass('metric-card')
+    expect(card).not.toHaveClass('metric-card--healthy')
+    expect(card).not.toHaveClass('metric-card--warning')
+    expect(card).not.toHaveClass('metric-card--critical')
+  })
+})

--- a/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
@@ -1,5 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import { MetricCard } from '@components/Experiments/MetricCard'
+import type { Point } from '@utils/downsample'
+
+const SAMPLE_SPARKLINE: Point[] = [
+  { step: 0, value: 0.391 },
+  { step: 100, value: 0.38 },
+  { step: 200, value: 0.36 },
+  { step: 300, value: 0.35 },
+  { step: 400, value: 0.342 },
+]
 
 describe('MetricCard', () => {
   it('renders label and formatted value', () => {
@@ -71,5 +80,84 @@ describe('MetricCard', () => {
     expect(card).not.toHaveClass('metric-card--healthy')
     expect(card).not.toHaveClass('metric-card--warning')
     expect(card).not.toHaveClass('metric-card--critical')
+  })
+
+  it('renders inline sparkline SVG when sparklinePoints are provided', () => {
+    render(
+      <MetricCard
+        label="Loss"
+        value={0.342}
+        metricName="loss"
+        trend="down"
+        health="healthy"
+        sparklinePoints={SAMPLE_SPARKLINE}
+      />
+    )
+    expect(screen.getByTestId('metric-sparkline')).toBeInTheDocument()
+  })
+
+  it('does not render sparkline when sparklinePoints is undefined', () => {
+    render(
+      <MetricCard label="Loss" value={0.342} metricName="loss" trend="down" health="healthy" />
+    )
+    expect(screen.queryByTestId('metric-sparkline')).not.toBeInTheDocument()
+  })
+
+  it('renders trend percentage when sparklinePoints are provided', () => {
+    // 0.342 from 0.391 = (0.342 - 0.391) / 0.391 = -12.5%
+    render(
+      <MetricCard
+        label="Loss"
+        value={0.342}
+        metricName="loss"
+        trend="down"
+        health="healthy"
+        sparklinePoints={SAMPLE_SPARKLINE}
+      />
+    )
+    const trendEl = screen.getByTestId('trend-indicator')
+    expect(trendEl).toHaveTextContent(/-\d+\.?\d*%/)
+  })
+
+  it('renders subtitle showing start value', () => {
+    render(
+      <MetricCard
+        label="Loss"
+        value={0.342}
+        metricName="loss"
+        trend="down"
+        health="healthy"
+        sparklinePoints={SAMPLE_SPARKLINE}
+      />
+    )
+    expect(screen.getByTestId('metric-subtitle')).toHaveTextContent('from 0.3910 at start')
+  })
+
+  it('does not render subtitle when sparklinePoints is undefined', () => {
+    render(
+      <MetricCard label="Loss" value={0.342} metricName="loss" trend="down" health="healthy" />
+    )
+    expect(screen.queryByTestId('metric-subtitle')).not.toBeInTheDocument()
+  })
+
+  it('formats subtitle start value using metric-specific formatting', () => {
+    const klPoints: Point[] = [
+      { step: 0, value: 0.000012 },
+      { step: 100, value: 0.000014 },
+      { step: 200, value: 0.000016 },
+      { step: 300, value: 0.000018 },
+      { step: 400, value: 0.00002 },
+    ]
+    render(
+      <MetricCard
+        label="KL Divergence"
+        value={0.00002}
+        metricName="kl"
+        trend="up"
+        health="warning"
+        sparklinePoints={klPoints}
+      />
+    )
+    expect(screen.getByTestId('metric-subtitle')).toHaveTextContent('from 0.000012 at start')
   })
 })

--- a/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricCard.test.tsx
@@ -6,7 +6,7 @@ describe('MetricCard', () => {
     render(
       <MetricCard label="Loss" value={0.2341} metricName="loss" trend="down" health="healthy" />
     )
-    expect(screen.getByText('LOSS')).toBeInTheDocument()
+    expect(screen.getByText('Loss')).toBeInTheDocument()
     expect(screen.getByText('0.2341')).toBeInTheDocument()
   })
 

--- a/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
@@ -19,15 +19,15 @@ describe('MetricsGrid', () => {
       new metrics.Metric({
         experiment_id: 'exp-1',
         step: 1,
-        name: 'loss',
-        value: 2.5,
+        name: 'kl',
+        value: 0.045,
         timestamp: 1000,
       }),
       new metrics.Metric({
         experiment_id: 'exp-1',
         step: 1,
-        name: 'reward',
-        value: 0.3,
+        name: 'learning_rate',
+        value: 0.0003,
         timestamp: 1000,
       }),
     ])
@@ -39,10 +39,10 @@ describe('MetricsGrid', () => {
 
     render(<MetricsGrid experimentId="exp-1" />)
 
-    expect(screen.getByText('Loss')).toBeInTheDocument()
-    expect(screen.getByText('Reward')).toBeInTheDocument()
     expect(screen.getByText('KL Divergence')).toBeInTheDocument()
     expect(screen.getByText('Learning Rate')).toBeInTheDocument()
+    expect(screen.getByText('Reward Variance')).toBeInTheDocument()
+    expect(screen.getByText('Policy Entropy')).toBeInTheDocument()
   })
 
   it('renders reward components card', async () => {

--- a/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
@@ -39,10 +39,10 @@ describe('MetricsGrid', () => {
 
     render(<MetricsGrid experimentId="exp-1" />)
 
-    expect(screen.getByText('LOSS')).toBeInTheDocument()
-    expect(screen.getByText('REWARD')).toBeInTheDocument()
-    expect(screen.getByText('KL DIVERGENCE')).toBeInTheDocument()
-    expect(screen.getByText('LEARNING RATE')).toBeInTheDocument()
+    expect(screen.getByText('Loss')).toBeInTheDocument()
+    expect(screen.getByText('Reward')).toBeInTheDocument()
+    expect(screen.getByText('KL Divergence')).toBeInTheDocument()
+    expect(screen.getByText('Learning Rate')).toBeInTheDocument()
   })
 
   it('renders reward components card', async () => {
@@ -76,7 +76,7 @@ describe('MetricsGrid', () => {
 
     render(<MetricsGrid experimentId="exp-1" />)
 
-    expect(screen.getByText('REWARD COMPONENTS')).toBeInTheDocument()
+    expect(screen.getByText('Reward Components')).toBeInTheDocument()
     expect(screen.getByText('Helpfulness')).toBeInTheDocument()
   })
 

--- a/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
@@ -1,11 +1,7 @@
 import { render, screen, act } from '@testing-library/react'
 import { MetricsGrid } from '@components/Experiments/MetricsGrid'
 import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
-import {
-  __resetMockState,
-  RecordMetrics,
-  RecordRewardSignals,
-} from '../../../__mocks__/wailsjs/go/main/App'
+import { __resetMockState, RecordMetrics } from '../../../__mocks__/wailsjs/go/main/App'
 import { metrics } from '../../../__mocks__/wailsjs/go/models'
 
 beforeEach(() => {
@@ -45,39 +41,14 @@ describe('MetricsGrid', () => {
     expect(screen.getByText('Policy Entropy')).toBeInTheDocument()
   })
 
-  it('renders reward components card', async () => {
-    await RecordRewardSignals('exp-1', [
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'helpfulness',
-        value: 0.8,
-        distribution: '',
-      }),
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'harmlessness',
-        value: 0.7,
-        distribution: '',
-      }),
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'honesty',
-        value: 0.75,
-        distribution: '',
-      }),
-    ])
-
-    await act(async () => {
-      await useMetricsStore.getState().fetchLatestRewardSignals('exp-1')
-    })
-
+  it('renders reward hack status card', () => {
     render(<MetricsGrid experimentId="exp-1" />)
 
-    expect(screen.getByText('Reward Components')).toBeInTheDocument()
-    expect(screen.getByText('Helpfulness')).toBeInTheDocument()
+    expect(screen.getByText('Reward Hack Detection')).toBeInTheDocument()
+    expect(screen.getByText('Length Gaming')).toBeInTheDocument()
+    expect(screen.getByText('Sycophancy')).toBeInTheDocument()
+    expect(screen.getByText('KL Drift')).toBeInTheDocument()
+    expect(screen.getByText('Reward Collapse')).toBeInTheDocument()
   })
 
   it('shows em dash values when no metrics available', () => {

--- a/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, act } from '@testing-library/react'
+import { MetricsGrid } from '@components/Experiments/MetricsGrid'
+import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
+import {
+  __resetMockState,
+  RecordMetrics,
+  RecordRewardSignals,
+} from '../../../__mocks__/wailsjs/go/main/App'
+import { metrics } from '../../../__mocks__/wailsjs/go/models'
+
+beforeEach(() => {
+  __resetMockState()
+  __resetMetricsStore()
+})
+
+describe('MetricsGrid', () => {
+  it('renders four metric cards', async () => {
+    await RecordMetrics('exp-1', [
+      new metrics.Metric({
+        experiment_id: 'exp-1',
+        step: 1,
+        name: 'loss',
+        value: 2.5,
+        timestamp: 1000,
+      }),
+      new metrics.Metric({
+        experiment_id: 'exp-1',
+        step: 1,
+        name: 'reward',
+        value: 0.3,
+        timestamp: 1000,
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestMetrics('exp-1')
+      await useMetricsStore.getState().fetchSparklineData('exp-1')
+    })
+
+    render(<MetricsGrid experimentId="exp-1" />)
+
+    expect(screen.getByText('LOSS')).toBeInTheDocument()
+    expect(screen.getByText('REWARD')).toBeInTheDocument()
+    expect(screen.getByText('KL DIVERGENCE')).toBeInTheDocument()
+    expect(screen.getByText('LEARNING RATE')).toBeInTheDocument()
+  })
+
+  it('renders reward components card', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.8,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'harmlessness',
+        value: 0.7,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'honesty',
+        value: 0.75,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-1')
+    })
+
+    render(<MetricsGrid experimentId="exp-1" />)
+
+    expect(screen.getByText('REWARD COMPONENTS')).toBeInTheDocument()
+    expect(screen.getByText('Helpfulness')).toBeInTheDocument()
+  })
+
+  it('shows em dash values when no metrics available', () => {
+    render(<MetricsGrid experimentId="exp-empty" />)
+    // All values should show em dash
+    const dashes = screen.getAllByText('\u2014')
+    expect(dashes.length).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/frontend/src/__tests__/components/Experiments/RewardComponentsCard.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/RewardComponentsCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { RewardComponentsCard } from '@components/Experiments/RewardComponentsCard'
+
+describe('RewardComponentsCard', () => {
+  const balancedComponents = [
+    { component: 'helpfulness', value: 0.82, step: 100 },
+    { component: 'harmlessness', value: 0.74, step: 100 },
+    { component: 'honesty', value: 0.79, step: 100 },
+  ]
+
+  it('renders all three component labels', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('Helpfulness')).toBeInTheDocument()
+    expect(screen.getByText('Harmlessness')).toBeInTheDocument()
+    expect(screen.getByText('Honesty')).toBeInTheDocument()
+  })
+
+  it('renders component values', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('0.82')).toBeInTheDocument()
+    expect(screen.getByText('0.74')).toBeInTheDocument()
+    expect(screen.getByText('0.79')).toBeInTheDocument()
+  })
+
+  it('displays step number', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    expect(screen.getByText('Step 100')).toBeInTheDocument()
+  })
+
+  it('applies healthy class when components are balanced', () => {
+    const { container } = render(<RewardComponentsCard components={balancedComponents} />)
+    expect(container.firstChild).toHaveClass('metric-card--healthy')
+  })
+
+  it('applies warning class when components diverge', () => {
+    const diverged = [
+      { component: 'helpfulness', value: 0.8, step: 100 },
+      { component: 'harmlessness', value: 0.3, step: 100 },
+      { component: 'honesty', value: 0.7, step: 100 },
+    ]
+    const { container } = render(<RewardComponentsCard components={diverged} />)
+    expect(container.firstChild).toHaveClass('metric-card--warning')
+  })
+
+  it('renders bar elements for each component', () => {
+    render(<RewardComponentsCard components={balancedComponents} />)
+    const bars = screen.getAllByTestId('reward-bar')
+    expect(bars).toHaveLength(3)
+  })
+
+  it('renders empty state when no components', () => {
+    render(<RewardComponentsCard components={[]} />)
+    expect(screen.getByText('No reward signal data')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/components/Experiments/RewardHackStatusCard.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/RewardHackStatusCard.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import { RewardHackStatusCard } from '@components/Experiments/RewardHackStatusCard'
+import type { DetectionStatus } from '@components/Experiments/RewardHackStatusCard'
+
+const allClear: DetectionStatus[] = [
+  { pattern: 'Length Gaming', status: 'clear', confidence: null },
+  { pattern: 'Sycophancy', status: 'clear', confidence: null },
+  { pattern: 'KL Drift', status: 'clear', confidence: null },
+  { pattern: 'Reward Collapse', status: 'clear', confidence: null },
+]
+
+const withWarning: DetectionStatus[] = [
+  { pattern: 'Length Gaming', status: 'clear', confidence: null },
+  { pattern: 'Sycophancy', status: 'elevated', confidence: 0.68 },
+  { pattern: 'KL Drift', status: 'monitoring', confidence: null },
+  { pattern: 'Reward Collapse', status: 'clear', confidence: null },
+]
+
+describe('RewardHackStatusCard', () => {
+  it('renders the card title', () => {
+    render(<RewardHackStatusCard detections={allClear} />)
+    expect(screen.getByText('Reward Hack Detection')).toBeInTheDocument()
+  })
+
+  it('renders all 4 detection pattern names', () => {
+    render(<RewardHackStatusCard detections={allClear} />)
+    expect(screen.getByText('Length Gaming')).toBeInTheDocument()
+    expect(screen.getByText('Sycophancy')).toBeInTheDocument()
+    expect(screen.getByText('KL Drift')).toBeInTheDocument()
+    expect(screen.getByText('Reward Collapse')).toBeInTheDocument()
+  })
+
+  it('shows "No signal" label for clear status', () => {
+    render(<RewardHackStatusCard detections={allClear} />)
+    const labels = screen.getAllByText('No signal')
+    expect(labels.length).toBe(4)
+  })
+
+  it('shows correct status labels for elevated and monitoring', () => {
+    render(<RewardHackStatusCard detections={withWarning} />)
+    expect(screen.getByText('Elevated')).toBeInTheDocument()
+    expect(screen.getByText('Monitoring')).toBeInTheDocument()
+  })
+
+  it('renders confidence value when present', () => {
+    render(<RewardHackStatusCard detections={withWarning} />)
+    expect(screen.getByText('0.68')).toBeInTheDocument()
+  })
+
+  it('renders em dash for confidence when null', () => {
+    render(<RewardHackStatusCard detections={allClear} />)
+    const dashes = screen.getAllByTestId('detection-confidence')
+    expect(dashes[0]).toHaveTextContent('\u2014')
+  })
+
+  it('applies healthy border when all patterns are clear', () => {
+    const { container } = render(<RewardHackStatusCard detections={allClear} />)
+    expect(container.firstChild).toHaveClass('metric-card--healthy')
+  })
+
+  it('applies warning border when any pattern is elevated', () => {
+    const { container } = render(<RewardHackStatusCard detections={withWarning} />)
+    expect(container.firstChild).toHaveClass('metric-card--warning')
+  })
+
+  it('applies critical border when any pattern is detected', () => {
+    const detected: DetectionStatus[] = [
+      { pattern: 'Length Gaming', status: 'detected', confidence: 0.92 },
+      { pattern: 'Sycophancy', status: 'clear', confidence: null },
+      { pattern: 'KL Drift', status: 'clear', confidence: null },
+      { pattern: 'Reward Collapse', status: 'clear', confidence: null },
+    ]
+    const { container } = render(<RewardHackStatusCard detections={detected} />)
+    expect(container.firstChild).toHaveClass('metric-card--critical')
+  })
+
+  it('shows summary footer with count of non-clear patterns', () => {
+    render(<RewardHackStatusCard detections={withWarning} />)
+    expect(screen.getByTestId('hack-summary')).toHaveTextContent('2 patterns under observation')
+  })
+
+  it('shows "All clear" summary when no patterns active', () => {
+    render(<RewardHackStatusCard detections={allClear} />)
+    expect(screen.getByTestId('hack-summary')).toHaveTextContent('All clear')
+  })
+
+  it('renders health dot for each detection row', () => {
+    render(<RewardHackStatusCard detections={withWarning} />)
+    const rows = screen.getAllByTestId('detection-row')
+    expect(rows).toHaveLength(4)
+  })
+
+  it('displays step number when provided', () => {
+    render(<RewardHackStatusCard detections={allClear} step={12400} />)
+    expect(screen.getByText('Step 12,400')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx
+++ b/frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, act } from '@testing-library/react'
 import { MainPanel } from '@components/layout/panels/MainPanel'
 import { useExperimentStore } from '@stores/experimentStore'
+import { useMetricsStore } from '@stores/metricsStore'
 import { experiment } from '../../../../__mocks__/wailsjs/go/models'
 
 // Mock the Wails runtime (EventsOn) so experimentStore can import
@@ -10,6 +11,9 @@ jest.mock('../../../../../wailsjs/runtime/runtime', () => ({
 
 jest.mock('../../../../../wailsjs/go/main/App', () => ({
   ListExperiments: jest.fn().mockResolvedValue([]),
+  GetLatestMetrics: jest.fn().mockResolvedValue([]),
+  QueryMetrics: jest.fn().mockResolvedValue([]),
+  QueryRewardSignals: jest.fn().mockResolvedValue([]),
 }))
 
 function makeExperiment(overrides: Partial<Record<string, unknown>> = {}): experiment.Experiment {
@@ -102,5 +106,56 @@ describe('MainPanel', () => {
     })
     rerender(<MainPanel />)
     expect(screen.getByText('exp-beta')).toBeInTheDocument()
+  })
+
+  it('shows metrics grid when experiment is selected', () => {
+    const exp = makeExperiment()
+    useExperimentStore.setState({
+      experiments: [exp],
+      selectedId: exp.id,
+    })
+    render(<MainPanel />)
+    expect(screen.getByTestId('metrics-grid')).toBeInTheDocument()
+  })
+
+  it('shows charts area when experiment is selected', () => {
+    const exp = makeExperiment()
+    useExperimentStore.setState({
+      experiments: [exp],
+      selectedId: exp.id,
+    })
+    render(<MainPanel />)
+    expect(screen.getByText('Overview')).toBeInTheDocument()
+    expect(screen.getByText('Chart visualization coming soon')).toBeInTheDocument()
+  })
+
+  it('shows step count in header when sparkline data is available', () => {
+    const exp = makeExperiment()
+    useExperimentStore.setState({
+      experiments: [exp],
+      selectedId: exp.id,
+    })
+    useMetricsStore.setState({
+      sparklineData: {
+        [exp.id]: {
+          loss: [
+            { step: 100, value: 2.5 },
+            { step: 12400, value: 0.5 },
+          ],
+        },
+      },
+    })
+    render(<MainPanel />)
+    expect(screen.getByTestId('step-count')).toHaveTextContent('Step 12,400')
+  })
+
+  it('does not show step count when no sparkline data', () => {
+    const exp = makeExperiment()
+    useExperimentStore.setState({
+      experiments: [exp],
+      selectedId: exp.id,
+    })
+    render(<MainPanel />)
+    expect(screen.queryByTestId('step-count')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/stores/metricsStore.test.ts
+++ b/frontend/src/__tests__/stores/metricsStore.test.ts
@@ -2,7 +2,7 @@ import { act } from '@testing-library/react'
 import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
 import { __resetMockState } from '../../__mocks__/wailsjs/go/main/App'
 import { metrics } from '../../__mocks__/wailsjs/go/models'
-import { RecordMetrics } from '../../__mocks__/wailsjs/go/main/App'
+import { RecordMetrics, RecordRewardSignals } from '../../__mocks__/wailsjs/go/main/App'
 
 beforeEach(() => {
   __resetMockState()
@@ -162,5 +162,63 @@ describe('useMetricsStore', () => {
     })
     expect(useMetricsStore.getState().sparklineData['exp-a']['loss']).toHaveLength(1)
     expect(useMetricsStore.getState().sparklineData['exp-b']['loss']).toHaveLength(1)
+  })
+})
+
+describe('reward signal support', () => {
+  it('fetchLatestRewardSignals populates state for an experiment', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.82,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'helpfulness',
+        value: 0.85,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'harmlessness',
+        value: 0.74,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'honesty',
+        value: 0.79,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-1')
+    })
+
+    const signals = useMetricsStore.getState().latestRewardSignals['exp-1']
+    expect(signals).toBeDefined()
+    expect(signals).toHaveLength(3)
+    expect(signals.find((s: { component: string }) => s.component === 'helpfulness')?.value).toBe(
+      0.85
+    )
+    expect(signals.find((s: { component: string }) => s.component === 'harmlessness')?.value).toBe(
+      0.74
+    )
+  })
+
+  it('returns empty array for experiment with no reward signals', async () => {
+    await act(async () => {
+      await useMetricsStore.getState().fetchLatestRewardSignals('exp-none')
+    })
+
+    const signals = useMetricsStore.getState().latestRewardSignals['exp-none']
+    expect(signals).toEqual([])
   })
 })

--- a/frontend/src/__tests__/utils/formatting.test.ts
+++ b/frontend/src/__tests__/utils/formatting.test.ts
@@ -1,4 +1,4 @@
-import { formatDuration, formatMetricValue } from '@utils/formatting'
+import { formatDuration, formatMetricValue, formatStepCount } from '@utils/formatting'
 
 describe('formatDuration', () => {
   // Duration is key experiment metadata shown on every card.
@@ -76,5 +76,29 @@ describe('formatMetricValue', () => {
   // Undefined values also represent missing data — display as em dash.
   it('returns em dash for undefined', () => {
     expect(formatMetricValue('loss', undefined)).toBe('\u2014')
+  })
+})
+
+describe('formatMetricValue — extended metrics', () => {
+  it('formats kl with 6 decimal places', () => {
+    expect(formatMetricValue('kl', 0.0423567)).toBe('0.042357')
+  })
+
+  it('formats learning_rate in scientific notation', () => {
+    expect(formatMetricValue('learning_rate', 0.00003)).toBe('3.00e-5')
+  })
+})
+
+describe('formatStepCount', () => {
+  it('formats step count with comma separators', () => {
+    expect(formatStepCount(12400)).toBe('12,400')
+  })
+
+  it('formats small step counts without commas', () => {
+    expect(formatStepCount(50)).toBe('50')
+  })
+
+  it('formats zero', () => {
+    expect(formatStepCount(0)).toBe('0')
   })
 })

--- a/frontend/src/__tests__/utils/health.test.ts
+++ b/frontend/src/__tests__/utils/health.test.ts
@@ -104,4 +104,18 @@ describe('assessRewardDivergence', () => {
     ]
     expect(assessRewardDivergence(components)).toBe('healthy')
   })
+
+  it('returns "warning" when negative values diverge beyond threshold', () => {
+    const components = [
+      { name: 'helpfulness', value: -0.8 },
+      { name: 'harmlessness', value: -0.3 },
+      { name: 'honesty', value: -0.7 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('warning')
+  })
+
+  it('returns "healthy" for a single component', () => {
+    const components = [{ name: 'helpfulness', value: 0.8 }]
+    expect(assessRewardDivergence(components)).toBe('healthy')
+  })
 })

--- a/frontend/src/__tests__/utils/health.test.ts
+++ b/frontend/src/__tests__/utils/health.test.ts
@@ -1,4 +1,4 @@
-import { computeTrend, assessHealth, assessRewardDivergence } from '@utils/health'
+import { computeTrend, assessHealth, assessRewardDivergence, deriveDetections } from '@utils/health'
 import type { Point } from '@utils/downsample'
 
 describe('computeTrend', () => {
@@ -137,5 +137,68 @@ describe('assessRewardDivergence', () => {
   it('returns "healthy" for a single component', () => {
     const components = [{ name: 'helpfulness', value: 0.8 }]
     expect(assessRewardDivergence(components)).toBe('healthy')
+  })
+})
+
+describe('deriveDetections', () => {
+  const balanced = [
+    { name: 'helpfulness', value: 0.8 },
+    { name: 'harmlessness', value: 0.7 },
+    { name: 'honesty', value: 0.75 },
+  ]
+
+  it('returns all clear when trends are healthy', () => {
+    const results = deriveDetections(
+      { kl: 'flat', reward: 'up', reward_variance: 'flat', policy_entropy: 'flat' },
+      balanced
+    )
+    expect(results.every((r) => r.status === 'clear')).toBe(true)
+  })
+
+  it('elevates sycophancy when KL rising and entropy dropping', () => {
+    const results = deriveDetections(
+      { kl: 'up', policy_entropy: 'down', reward: 'flat', reward_variance: 'flat' },
+      balanced
+    )
+    const syc = results.find((r) => r.pattern === 'Sycophancy')
+    expect(syc?.status).toBe('elevated')
+  })
+
+  it('sets KL drift to monitoring when KL is rising', () => {
+    const results = deriveDetections(
+      { kl: 'up', policy_entropy: 'flat', reward: 'flat', reward_variance: 'flat' },
+      balanced
+    )
+    const kl = results.find((r) => r.pattern === 'KL Drift')
+    expect(kl?.status).toBe('monitoring')
+  })
+
+  it('elevates length gaming when reward up and variance down', () => {
+    const results = deriveDetections(
+      { kl: 'flat', reward: 'up', reward_variance: 'down', policy_entropy: 'flat' },
+      balanced
+    )
+    const lg = results.find((r) => r.pattern === 'Length Gaming')
+    expect(lg?.status).toBe('elevated')
+  })
+
+  it('elevates reward collapse when variance down and components diverge', () => {
+    const diverged = [
+      { name: 'helpfulness', value: 0.8 },
+      { name: 'harmlessness', value: 0.3 },
+      { name: 'honesty', value: 0.7 },
+    ]
+    const results = deriveDetections(
+      { kl: 'flat', reward: 'flat', reward_variance: 'down', policy_entropy: 'flat' },
+      diverged
+    )
+    const rc = results.find((r) => r.pattern === 'Reward Collapse')
+    expect(rc?.status).toBe('elevated')
+  })
+
+  it('handles missing trends gracefully', () => {
+    const results = deriveDetections({}, [])
+    expect(results).toHaveLength(4)
+    expect(results.every((r) => r.status === 'clear')).toBe(true)
   })
 })

--- a/frontend/src/__tests__/utils/health.test.ts
+++ b/frontend/src/__tests__/utils/health.test.ts
@@ -1,0 +1,107 @@
+import { computeTrend, assessHealth, assessRewardDivergence } from '@utils/health'
+import type { Point } from '@utils/downsample'
+
+describe('computeTrend', () => {
+  it('returns "insufficient" when data has fewer than 4 points', () => {
+    const data: Point[] = [
+      { step: 1, value: 1.0 },
+      { step: 2, value: 0.9 },
+    ]
+    expect(computeTrend(data)).toBe('insufficient')
+  })
+
+  it('returns "down" when recent average is lower than previous average', () => {
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: i < 10 ? 2.0 : 1.0,
+    }))
+    expect(computeTrend(data)).toBe('down')
+  })
+
+  it('returns "up" when recent average is higher than previous average', () => {
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: i < 10 ? 1.0 : 2.0,
+    }))
+    expect(computeTrend(data)).toBe('up')
+  })
+
+  it('returns "flat" when averages are within 1% of each other', () => {
+    const data: Point[] = Array.from({ length: 20 }, (_, i) => ({
+      step: i + 1,
+      value: 1.0,
+    }))
+    expect(computeTrend(data)).toBe('flat')
+  })
+})
+
+describe('assessHealth', () => {
+  it('returns "healthy" for decreasing loss', () => {
+    expect(assessHealth('loss', 'down')).toBe('healthy')
+  })
+
+  it('returns "warning" for flat loss', () => {
+    expect(assessHealth('loss', 'flat')).toBe('warning')
+  })
+
+  it('returns "critical" for increasing loss', () => {
+    expect(assessHealth('loss', 'up')).toBe('critical')
+  })
+
+  it('returns "healthy" for increasing reward', () => {
+    expect(assessHealth('reward', 'up')).toBe('healthy')
+  })
+
+  it('returns "critical" for decreasing reward', () => {
+    expect(assessHealth('reward', 'down')).toBe('critical')
+  })
+
+  it('returns "healthy" for stable kl', () => {
+    expect(assessHealth('kl', 'flat')).toBe('healthy')
+  })
+
+  it('returns "warning" for increasing kl', () => {
+    expect(assessHealth('kl', 'up')).toBe('warning')
+  })
+
+  it('returns "none" for insufficient data', () => {
+    expect(assessHealth('loss', 'insufficient')).toBe('none')
+  })
+
+  it('returns "none" for metrics without health rules (e.g., learning_rate)', () => {
+    expect(assessHealth('learning_rate', 'up')).toBe('none')
+  })
+})
+
+describe('assessRewardDivergence', () => {
+  it('returns "none" when components array is empty', () => {
+    expect(assessRewardDivergence([])).toBe('none')
+  })
+
+  it('returns "healthy" when components are balanced', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.8 },
+      { name: 'harmlessness', value: 0.7 },
+      { name: 'honesty', value: 0.75 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('healthy')
+  })
+
+  it('returns "warning" when one component is >2x another AND spread > 0.1', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.8 },
+      { name: 'harmlessness', value: 0.3 },
+      { name: 'honesty', value: 0.7 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('warning')
+  })
+
+  it('returns "healthy" when ratio exceeds 2x but spread is under 0.1', () => {
+    const components = [
+      { name: 'helpfulness', value: 0.06 },
+      { name: 'harmlessness', value: 0.02 },
+      { name: 'honesty', value: 0.05 },
+    ]
+    expect(assessRewardDivergence(components)).toBe('healthy')
+  })
+})

--- a/frontend/src/__tests__/utils/health.test.ts
+++ b/frontend/src/__tests__/utils/health.test.ts
@@ -71,6 +71,26 @@ describe('assessHealth', () => {
   it('returns "none" for metrics without health rules (e.g., learning_rate)', () => {
     expect(assessHealth('learning_rate', 'up')).toBe('none')
   })
+
+  it('returns "warning" for decreasing reward_variance', () => {
+    expect(assessHealth('reward_variance', 'down')).toBe('warning')
+  })
+
+  it('returns "healthy" for stable reward_variance', () => {
+    expect(assessHealth('reward_variance', 'flat')).toBe('healthy')
+  })
+
+  it('returns "warning" for decreasing policy_entropy', () => {
+    expect(assessHealth('policy_entropy', 'down')).toBe('warning')
+  })
+
+  it('returns "warning" for increasing policy_entropy', () => {
+    expect(assessHealth('policy_entropy', 'up')).toBe('warning')
+  })
+
+  it('returns "healthy" for stable policy_entropy', () => {
+    expect(assessHealth('policy_entropy', 'flat')).toBe('healthy')
+  })
 })
 
 describe('assessRewardDivergence', () => {

--- a/frontend/src/components/Experiments/ChartsArea.css
+++ b/frontend/src/components/Experiments/ChartsArea.css
@@ -1,0 +1,63 @@
+.charts-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+  margin-top: var(--spacing-md);
+}
+
+.charts-area__tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.chart-tab {
+  padding: 8px 16px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.chart-tab:hover {
+  color: var(--color-text-secondary);
+}
+
+.chart-tab--active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+.charts-area__placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-2xl);
+  color: var(--color-text-muted);
+}
+
+.charts-area__placeholder-icon {
+  width: 32px;
+  height: 32px;
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+
+.charts-area__placeholder-text {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.charts-area__placeholder-subtext {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}

--- a/frontend/src/components/Experiments/ChartsArea.css
+++ b/frontend/src/components/Experiments/ChartsArea.css
@@ -11,7 +11,7 @@
   border-bottom: 1px solid var(--color-border-muted);
 }
 
-.chart-tab {
+.charts-area__tab {
   padding: 8px 16px;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
@@ -25,11 +25,11 @@
     border-color var(--transition-fast);
 }
 
-.chart-tab:hover {
+.charts-area__tab:hover {
   color: var(--color-text-secondary);
 }
 
-.chart-tab--active {
+.charts-area__tab--active {
   color: var(--color-accent);
   border-bottom-color: var(--color-accent);
 }

--- a/frontend/src/components/Experiments/ChartsArea.tsx
+++ b/frontend/src/components/Experiments/ChartsArea.tsx
@@ -13,7 +13,7 @@ export function ChartsArea() {
         {TABS.map((tab) => (
           <button
             key={tab}
-            className={`chart-tab ${activeTab === tab ? 'chart-tab--active' : ''}`}
+            className={`charts-area__tab ${activeTab === tab ? 'charts-area__tab--active' : ''}`}
             onClick={() => setActiveTab(tab)}
           >
             {tab}

--- a/frontend/src/components/Experiments/ChartsArea.tsx
+++ b/frontend/src/components/Experiments/ChartsArea.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { LineChart } from 'lucide-react'
+import './ChartsArea.css'
+
+const TABS = ['Overview', 'Reward Components', 'Diagnostics'] as const
+
+export function ChartsArea() {
+  const [activeTab, setActiveTab] = useState<string>(TABS[0])
+
+  return (
+    <div className="charts-area">
+      <div className="charts-area__tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab}
+            className={`chart-tab ${activeTab === tab ? 'chart-tab--active' : ''}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="charts-area__placeholder">
+        <LineChart className="charts-area__placeholder-icon" />
+        <span className="charts-area__placeholder-text">Chart visualization coming soon</span>
+        <span className="charts-area__placeholder-subtext">uPlot integration in Phase 3</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Experiments/MetricCard.css
+++ b/frontend/src/components/Experiments/MetricCard.css
@@ -65,6 +65,12 @@
   }
 }
 
+.metric-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .metric-card__label {
   font-size: 10px;
   font-weight: var(--font-weight-semibold);
@@ -81,13 +87,39 @@
   line-height: 1.2;
 }
 
+.metric-card__subtitle {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.metric-card__sparkline {
+  width: 100%;
+  height: 32px;
+  color: var(--color-accent);
+  margin-top: 4px;
+}
+
+.metric-card--healthy .metric-card__sparkline {
+  color: var(--color-success);
+}
+
+.metric-card--warning .metric-card__sparkline {
+  color: var(--color-warning);
+}
+
+.metric-card--critical .metric-card__sparkline {
+  color: var(--color-error);
+}
+
 .metric-card__trend {
   font-size: 11px;
   font-family: var(--font-mono);
   font-weight: var(--font-weight-medium);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
+  white-space: nowrap;
 }
 
 .metric-card__trend--healthy {

--- a/frontend/src/components/Experiments/MetricCard.css
+++ b/frontend/src/components/Experiments/MetricCard.css
@@ -3,22 +3,66 @@
   border: 1px solid var(--color-border-muted);
   border-radius: var(--radius-lg);
   padding: 12px 14px;
-  border-left: 3px solid var(--color-border-muted);
   display: flex;
   flex-direction: column;
   gap: 4px;
+  position: relative;
 }
 
 .metric-card--healthy {
-  border-left-color: var(--color-success);
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.04);
+  box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.08);
 }
 
 .metric-card--warning {
-  border-left-color: var(--color-warning);
+  border-color: rgba(245, 158, 11, 0.4);
+  background: var(--color-warning-subtle);
+  box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.1);
 }
 
 .metric-card--critical {
-  border-left-color: var(--color-error);
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.04);
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.1);
+}
+
+.metric-card__health-dot {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.metric-card__health-dot--healthy {
+  background: var(--color-success);
+  box-shadow: 0 0 6px rgba(16, 185, 129, 0.5);
+}
+
+.metric-card__health-dot--warning {
+  background: var(--color-warning);
+  box-shadow: 0 0 6px rgba(245, 158, 11, 0.5);
+  animation: pulse-warning 1s infinite;
+}
+
+.metric-card__health-dot--critical {
+  background: var(--color-error);
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.6);
+  animation: pulse-critical 0.8s infinite;
+}
+
+@keyframes pulse-critical {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 8px rgba(239, 68, 68, 0.6);
+  }
+  50% {
+    opacity: 0.7;
+    box-shadow: 0 0 14px rgba(239, 68, 68, 0.8);
+  }
 }
 
 .metric-card__label {
@@ -46,16 +90,16 @@
   gap: 4px;
 }
 
-.metric-card__trend--up {
-  color: var(--color-error);
-}
-
-.metric-card__trend--down {
+.metric-card__trend--healthy {
   color: var(--color-success);
 }
 
-.metric-card__trend--flat {
-  color: var(--color-text-muted);
+.metric-card__trend--warning {
+  color: var(--color-warning);
+}
+
+.metric-card__trend--critical {
+  color: var(--color-error);
 }
 
 /* Reward Components Card */

--- a/frontend/src/components/Experiments/MetricCard.css
+++ b/frontend/src/components/Experiments/MetricCard.css
@@ -1,0 +1,128 @@
+.metric-card {
+  background: var(--color-bg-content);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  padding: 12px 14px;
+  border-left: 3px solid var(--color-border-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-card--healthy {
+  border-left-color: var(--color-success);
+}
+
+.metric-card--warning {
+  border-left-color: var(--color-warning);
+}
+
+.metric-card--critical {
+  border-left-color: var(--color-error);
+}
+
+.metric-card__label {
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.metric-card__value {
+  font-size: 20px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+
+.metric-card__trend {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.metric-card__trend--up {
+  color: var(--color-error);
+}
+
+.metric-card__trend--down {
+  color: var(--color-success);
+}
+
+.metric-card__trend--flat {
+  color: var(--color-text-muted);
+}
+
+/* Reward Components Card */
+.reward-components-card {
+  grid-column: span 2;
+}
+
+.reward-components-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reward-components-card__step {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.reward-components-card__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.reward-components-card__empty {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  padding: 8px 0;
+}
+
+.reward-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reward-bar__label {
+  font-size: 11px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.reward-bar__track {
+  flex: 1;
+  height: 6px;
+  background: var(--color-bg-panel);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.reward-bar__fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width var(--transition-normal);
+}
+
+.reward-bar__value {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  width: 36px;
+  text-align: right;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/Experiments/MetricCard.css
+++ b/frontend/src/components/Experiments/MetricCard.css
@@ -136,7 +136,7 @@
 
 /* Reward Components Card */
 .reward-components-card {
-  grid-column: span 2;
+  grid-column: 1 / -1;
 }
 
 .reward-components-card__header {

--- a/frontend/src/components/Experiments/MetricCard.tsx
+++ b/frontend/src/components/Experiments/MetricCard.tsx
@@ -1,4 +1,5 @@
 import { formatMetricValue } from '@utils/formatting'
+import type { Point } from '@utils/downsample'
 import type { Trend, HealthStatus } from '@utils/health'
 import './MetricCard.css'
 
@@ -8,6 +9,7 @@ interface MetricCardProps {
   metricName: string
   trend: Trend
   health: HealthStatus
+  sparklinePoints?: Point[]
 }
 
 const TREND_ARROWS: Record<Exclude<Trend, 'insufficient'>, string> = {
@@ -16,26 +18,92 @@ const TREND_ARROWS: Record<Exclude<Trend, 'insufficient'>, string> = {
   flat: '→',
 }
 
-export function MetricCard({ label, value, metricName, trend, health }: MetricCardProps) {
+function computePercentChange(
+  startValue: number,
+  currentValue: number | null | undefined
+): string | null {
+  if (currentValue == null || Math.abs(startValue) < 1e-10) return null
+  const pct = ((currentValue - startValue) / Math.abs(startValue)) * 100
+  const sign = pct >= 0 ? '+' : ''
+  return `${sign}${pct.toFixed(1)}%`
+}
+
+function buildSparklinePath(points: Point[], width: number, height: number): string {
+  if (points.length < 2) return ''
+
+  const steps = points.map((p) => p.step)
+  const values = points.map((p) => p.value)
+  const minStep = Math.min(...steps)
+  const maxStep = Math.max(...steps)
+  const minVal = Math.min(...values)
+  const maxVal = Math.max(...values)
+
+  const stepRange = maxStep - minStep || 1
+  const valRange = maxVal - minVal || 1
+  const padding = 2
+
+  return points
+    .map((p, i) => {
+      const x = ((p.step - minStep) / stepRange) * width
+      const y = padding + ((maxVal - p.value) / valRange) * (height - padding * 2)
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+}
+
+export function MetricCard({
+  label,
+  value,
+  metricName,
+  trend,
+  health,
+  sparklinePoints,
+}: MetricCardProps) {
   const healthClass = health !== 'none' ? `metric-card--${health}` : ''
   const trendColorClass =
     trend !== 'insufficient' && health !== 'none' ? `metric-card__trend--${health}` : ''
+
+  const startValue = sparklinePoints && sparklinePoints.length > 0 ? sparklinePoints[0].value : null
+  const percentChange = startValue != null ? computePercentChange(startValue, value) : null
 
   return (
     <div className={`metric-card ${healthClass}`} aria-label={`${label}: ${health} status`}>
       {health !== 'none' && (
         <span className={`metric-card__health-dot metric-card__health-dot--${health}`} />
       )}
-      <span className="metric-card__label">{label}</span>
+      <div className="metric-card__header">
+        <span className="metric-card__label">{label}</span>
+        {trend !== 'insufficient' && (
+          <span
+            className={`metric-card__trend ${trendColorClass}`}
+            data-testid="trend-indicator"
+            aria-label={`Trend: ${trend}`}
+          >
+            {TREND_ARROWS[trend]} {percentChange}
+          </span>
+        )}
+      </div>
       <span className="metric-card__value">{formatMetricValue(metricName, value)}</span>
-      {trend !== 'insufficient' && (
-        <span
-          className={`metric-card__trend ${trendColorClass}`}
-          data-testid="trend-indicator"
-          aria-label={`Trend: ${trend}`}
-        >
-          {TREND_ARROWS[trend]}
+      {startValue != null && (
+        <span className="metric-card__subtitle" data-testid="metric-subtitle">
+          from {formatMetricValue(metricName, startValue)} at start
         </span>
+      )}
+      {sparklinePoints && sparklinePoints.length >= 2 && (
+        <svg
+          className="metric-card__sparkline"
+          data-testid="metric-sparkline"
+          viewBox="0 0 100 32"
+          preserveAspectRatio="none"
+        >
+          <path
+            d={buildSparklinePath(sparklinePoints, 100, 32)}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
       )}
     </div>
   )

--- a/frontend/src/components/Experiments/MetricCard.tsx
+++ b/frontend/src/components/Experiments/MetricCard.tsx
@@ -18,14 +18,22 @@ const TREND_ARROWS: Record<Exclude<Trend, 'insufficient'>, string> = {
 
 export function MetricCard({ label, value, metricName, trend, health }: MetricCardProps) {
   const healthClass = health !== 'none' ? `metric-card--${health}` : ''
-  const trendClass = trend !== 'insufficient' ? `metric-card__trend--${trend}` : ''
+  const trendColorClass =
+    trend !== 'insufficient' && health !== 'none' ? `metric-card__trend--${health}` : ''
 
   return (
-    <div className={`metric-card ${healthClass}`}>
-      <span className="metric-card__label">{label.toUpperCase()}</span>
+    <div className={`metric-card ${healthClass}`} aria-label={`${label}: ${health} status`}>
+      {health !== 'none' && (
+        <span className={`metric-card__health-dot metric-card__health-dot--${health}`} />
+      )}
+      <span className="metric-card__label">{label}</span>
       <span className="metric-card__value">{formatMetricValue(metricName, value)}</span>
       {trend !== 'insufficient' && (
-        <span className={`metric-card__trend ${trendClass}`} data-testid="trend-indicator">
+        <span
+          className={`metric-card__trend ${trendColorClass}`}
+          data-testid="trend-indicator"
+          aria-label={`Trend: ${trend}`}
+        >
           {TREND_ARROWS[trend]}
         </span>
       )}

--- a/frontend/src/components/Experiments/MetricCard.tsx
+++ b/frontend/src/components/Experiments/MetricCard.tsx
@@ -1,0 +1,34 @@
+import { formatMetricValue } from '@utils/formatting'
+import type { Trend, HealthStatus } from '@utils/health'
+import './MetricCard.css'
+
+interface MetricCardProps {
+  label: string
+  value: number | null | undefined
+  metricName: string
+  trend: Trend
+  health: HealthStatus
+}
+
+const TREND_ARROWS: Record<Exclude<Trend, 'insufficient'>, string> = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+}
+
+export function MetricCard({ label, value, metricName, trend, health }: MetricCardProps) {
+  const healthClass = health !== 'none' ? `metric-card--${health}` : ''
+  const trendClass = trend !== 'insufficient' ? `metric-card__trend--${trend}` : ''
+
+  return (
+    <div className={`metric-card ${healthClass}`}>
+      <span className="metric-card__label">{label.toUpperCase()}</span>
+      <span className="metric-card__value">{formatMetricValue(metricName, value)}</span>
+      {trend !== 'insufficient' && (
+        <span className={`metric-card__trend ${trendClass}`} data-testid="trend-indicator">
+          {TREND_ARROWS[trend]}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Experiments/MetricsGrid.tsx
+++ b/frontend/src/components/Experiments/MetricsGrid.tsx
@@ -9,10 +9,10 @@ interface MetricsGridProps {
 }
 
 const METRIC_CARDS = [
-  { label: 'Loss', name: 'loss' },
-  { label: 'Reward', name: 'reward' },
   { label: 'KL Divergence', name: 'kl' },
   { label: 'Learning Rate', name: 'learning_rate' },
+  { label: 'Reward Variance', name: 'reward_variance' },
+  { label: 'Policy Entropy', name: 'policy_entropy' },
 ] as const
 
 export function MetricsGrid({ experimentId }: MetricsGridProps) {
@@ -45,6 +45,7 @@ export function MetricsGrid({ experimentId }: MetricsGridProps) {
             metricName={name}
             trend={trend}
             health={health}
+            sparklinePoints={points}
           />
         )
       })}

--- a/frontend/src/components/Experiments/MetricsGrid.tsx
+++ b/frontend/src/components/Experiments/MetricsGrid.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+import { useMetricsStore } from '@stores/metricsStore'
+import { computeTrend, assessHealth } from '@utils/health'
+import { MetricCard } from './MetricCard'
+import { RewardComponentsCard } from './RewardComponentsCard'
+
+interface MetricsGridProps {
+  experimentId: string
+}
+
+const METRIC_CARDS = [
+  { label: 'Loss', name: 'loss' },
+  { label: 'Reward', name: 'reward' },
+  { label: 'KL Divergence', name: 'kl' },
+  { label: 'Learning Rate', name: 'learning_rate' },
+] as const
+
+export function MetricsGrid({ experimentId }: MetricsGridProps) {
+  const latestMetrics = useMetricsStore((s) => s.latestMetrics[experimentId])
+  const sparklineData = useMetricsStore((s) => s.sparklineData[experimentId])
+  const latestRewardSignals = useMetricsStore((s) => s.latestRewardSignals[experimentId])
+  const fetchLatestMetrics = useMetricsStore((s) => s.fetchLatestMetrics)
+  const fetchSparklineData = useMetricsStore((s) => s.fetchSparklineData)
+  const fetchLatestRewardSignals = useMetricsStore((s) => s.fetchLatestRewardSignals)
+
+  useEffect(() => {
+    fetchLatestMetrics(experimentId)
+    fetchSparklineData(experimentId)
+    fetchLatestRewardSignals(experimentId)
+  }, [experimentId, fetchLatestMetrics, fetchSparklineData, fetchLatestRewardSignals])
+
+  return (
+    <div className="metrics-grid" data-testid="metrics-grid">
+      {METRIC_CARDS.map(({ label, name }) => {
+        const value = latestMetrics?.[name] ?? null
+        const points = sparklineData?.[name]
+        const trend = points ? computeTrend(points) : 'insufficient'
+        const health = assessHealth(name, trend)
+
+        return (
+          <MetricCard
+            key={name}
+            label={label}
+            value={value}
+            metricName={name}
+            trend={trend}
+            health={health}
+          />
+        )
+      })}
+      <RewardComponentsCard components={latestRewardSignals ?? []} />
+    </div>
+  )
+}

--- a/frontend/src/components/Experiments/MetricsGrid.tsx
+++ b/frontend/src/components/Experiments/MetricsGrid.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import { useMetricsStore } from '@stores/metricsStore'
-import { computeTrend, assessHealth } from '@utils/health'
+import { computeTrend, assessHealth, deriveDetections } from '@utils/health'
 import { MetricCard } from './MetricCard'
-import { RewardComponentsCard } from './RewardComponentsCard'
+import { RewardHackStatusCard } from './RewardHackStatusCard'
 
 interface MetricsGridProps {
   experimentId: string
@@ -29,6 +29,35 @@ export function MetricsGrid({ experimentId }: MetricsGridProps) {
     fetchLatestRewardSignals(experimentId)
   }, [experimentId, fetchLatestMetrics, fetchSparklineData, fetchLatestRewardSignals])
 
+  // Compute trends for cross-metric detection
+  const trends = {
+    kl: sparklineData?.kl ? computeTrend(sparklineData.kl) : undefined,
+    reward: sparklineData?.reward ? computeTrend(sparklineData.reward) : undefined,
+    reward_variance: sparklineData?.reward_variance
+      ? computeTrend(sparklineData.reward_variance)
+      : undefined,
+    policy_entropy: sparklineData?.policy_entropy
+      ? computeTrend(sparklineData.policy_entropy)
+      : undefined,
+  }
+
+  const rewardComponents = (latestRewardSignals ?? []).map((s) => ({
+    name: s.component,
+    value: s.value,
+  }))
+
+  const detections = deriveDetections(trends, rewardComponents)
+
+  // Derive latest step from sparkline data
+  let latestStep: number | null = null
+  if (sparklineData) {
+    for (const points of Object.values(sparklineData)) {
+      for (const p of points) {
+        if (latestStep === null || p.step > latestStep) latestStep = p.step
+      }
+    }
+  }
+
   return (
     <div className="metrics-grid" data-testid="metrics-grid">
       {METRIC_CARDS.map(({ label, name }) => {
@@ -49,7 +78,7 @@ export function MetricsGrid({ experimentId }: MetricsGridProps) {
           />
         )
       })}
-      <RewardComponentsCard components={latestRewardSignals ?? []} />
+      <RewardHackStatusCard detections={detections} step={latestStep} />
     </div>
   )
 }

--- a/frontend/src/components/Experiments/RewardComponentsCard.tsx
+++ b/frontend/src/components/Experiments/RewardComponentsCard.tsx
@@ -19,7 +19,7 @@ export function RewardComponentsCard({ components }: RewardComponentsCardProps) 
   if (components.length === 0) {
     return (
       <div className="metric-card reward-components-card">
-        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="metric-card__label">Reward Components</span>
         <span className="reward-components-card__empty">No reward signal data</span>
       </div>
     )
@@ -29,13 +29,13 @@ export function RewardComponentsCard({ components }: RewardComponentsCardProps) 
     components.map((c) => ({ name: c.component, value: c.value }))
   )
   const healthClass = health !== 'none' ? `metric-card--${health}` : ''
-  const maxValue = Math.max(...components.map((c) => c.value), 1)
+  const maxAbsValue = Math.max(...components.map((c) => Math.abs(c.value)), 1e-10)
   const step = Math.max(...components.map((c) => c.step))
 
   return (
     <div className={`metric-card reward-components-card ${healthClass}`}>
       <div className="reward-components-card__header">
-        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="metric-card__label">Reward Components</span>
         <span className="reward-components-card__step">Step {step.toLocaleString('en-US')}</span>
       </div>
       <div className="reward-components-card__bars">
@@ -45,7 +45,7 @@ export function RewardComponentsCard({ components }: RewardComponentsCardProps) 
             <div className="reward-bar__track">
               <div
                 className="reward-bar__fill"
-                style={{ width: `${(c.value / maxValue) * 100}%` }}
+                style={{ width: `${(Math.abs(c.value) / maxAbsValue) * 100}%` }}
               />
             </div>
             <span className="reward-bar__value">{c.value.toFixed(2)}</span>

--- a/frontend/src/components/Experiments/RewardComponentsCard.tsx
+++ b/frontend/src/components/Experiments/RewardComponentsCard.tsx
@@ -1,0 +1,57 @@
+import { assessRewardDivergence } from '@utils/health'
+import './MetricCard.css'
+
+interface RewardComponentData {
+  component: string
+  value: number
+  step: number
+}
+
+interface RewardComponentsCardProps {
+  components: RewardComponentData[]
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function RewardComponentsCard({ components }: RewardComponentsCardProps) {
+  if (components.length === 0) {
+    return (
+      <div className="metric-card reward-components-card">
+        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="reward-components-card__empty">No reward signal data</span>
+      </div>
+    )
+  }
+
+  const health = assessRewardDivergence(
+    components.map((c) => ({ name: c.component, value: c.value }))
+  )
+  const healthClass = health !== 'none' ? `metric-card--${health}` : ''
+  const maxValue = Math.max(...components.map((c) => c.value), 1)
+  const step = Math.max(...components.map((c) => c.step))
+
+  return (
+    <div className={`metric-card reward-components-card ${healthClass}`}>
+      <div className="reward-components-card__header">
+        <span className="metric-card__label">REWARD COMPONENTS</span>
+        <span className="reward-components-card__step">Step {step.toLocaleString('en-US')}</span>
+      </div>
+      <div className="reward-components-card__bars">
+        {components.map((c) => (
+          <div key={c.component} className="reward-bar" data-testid="reward-bar">
+            <span className="reward-bar__label">{capitalize(c.component)}</span>
+            <div className="reward-bar__track">
+              <div
+                className="reward-bar__fill"
+                style={{ width: `${(c.value / maxValue) * 100}%` }}
+              />
+            </div>
+            <span className="reward-bar__value">{c.value.toFixed(2)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Experiments/RewardHackStatusCard.css
+++ b/frontend/src/components/Experiments/RewardHackStatusCard.css
@@ -1,0 +1,93 @@
+.hack-status-card {
+  grid-column: 1 / -1;
+}
+
+.hack-status-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hack-status-card__step {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.hack-status-card__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.hack-row {
+  display: grid;
+  grid-template-columns: 8px 1fr 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.hack-row__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.hack-row__dot--clear {
+  background: var(--color-success);
+  box-shadow: 0 0 4px rgba(16, 185, 129, 0.4);
+}
+
+.hack-row__dot--monitoring {
+  background: var(--color-text-muted);
+  opacity: 0.6;
+}
+
+.hack-row__dot--elevated {
+  background: var(--color-warning);
+  box-shadow: 0 0 6px rgba(245, 158, 11, 0.5);
+}
+
+.hack-row__dot--detected {
+  background: var(--color-error);
+  box-shadow: 0 0 8px rgba(239, 68, 68, 0.6);
+  animation: pulse-critical 0.8s infinite;
+}
+
+.hack-row__pattern {
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.hack-row__status {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.hack-row__status--elevated {
+  color: var(--color-warning);
+}
+
+.hack-row__status--detected {
+  color: var(--color-error);
+  font-weight: var(--font-weight-semibold);
+}
+
+.hack-row__confidence {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  text-align: right;
+  min-width: 32px;
+}
+
+.hack-status-card__footer {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--color-border-muted);
+  font-size: 11px;
+  color: var(--color-text-muted);
+}

--- a/frontend/src/components/Experiments/RewardHackStatusCard.tsx
+++ b/frontend/src/components/Experiments/RewardHackStatusCard.tsx
@@ -1,0 +1,74 @@
+import { formatStepCount } from '@utils/formatting'
+import './RewardHackStatusCard.css'
+
+export type DetectionLevel = 'clear' | 'monitoring' | 'elevated' | 'detected'
+
+export interface DetectionStatus {
+  pattern: string
+  status: DetectionLevel
+  confidence: number | null
+}
+
+interface RewardHackStatusCardProps {
+  detections: DetectionStatus[]
+  step?: number | null
+}
+
+const STATUS_LABELS: Record<DetectionLevel, string> = {
+  clear: 'No signal',
+  monitoring: 'Monitoring',
+  elevated: 'Elevated',
+  detected: 'Detected',
+}
+
+const STATUS_DOT_CLASS: Record<DetectionLevel, string> = {
+  clear: 'hack-row__dot--clear',
+  monitoring: 'hack-row__dot--monitoring',
+  elevated: 'hack-row__dot--elevated',
+  detected: 'hack-row__dot--detected',
+}
+
+function deriveCardHealth(detections: DetectionStatus[]): string {
+  if (detections.some((d) => d.status === 'detected')) return 'metric-card--critical'
+  if (detections.some((d) => d.status === 'elevated' || d.status === 'monitoring'))
+    return 'metric-card--warning'
+  return 'metric-card--healthy'
+}
+
+function deriveSummary(detections: DetectionStatus[]): string {
+  const active = detections.filter((d) => d.status !== 'clear').length
+  if (active === 0) return 'All clear'
+  return `${active} pattern${active > 1 ? 's' : ''} under observation`
+}
+
+export function RewardHackStatusCard({ detections, step }: RewardHackStatusCardProps) {
+  const healthClass = deriveCardHealth(detections)
+
+  return (
+    <div className={`metric-card hack-status-card ${healthClass}`}>
+      <div className="hack-status-card__header">
+        <span className="metric-card__label">Reward Hack Detection</span>
+        {step != null && step > 0 && (
+          <span className="hack-status-card__step">Step {formatStepCount(step)}</span>
+        )}
+      </div>
+      <div className="hack-status-card__rows">
+        {detections.map((d) => (
+          <div key={d.pattern} className="hack-row" data-testid="detection-row">
+            <span className={`hack-row__dot ${STATUS_DOT_CLASS[d.status]}`} />
+            <span className="hack-row__pattern">{d.pattern}</span>
+            <span className={`hack-row__status hack-row__status--${d.status}`}>
+              {STATUS_LABELS[d.status]}
+            </span>
+            <span className="hack-row__confidence" data-testid="detection-confidence">
+              {d.confidence != null ? d.confidence.toFixed(2) : '\u2014'}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="hack-status-card__footer" data-testid="hack-summary">
+        {deriveSummary(detections)}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/panels/MainPanel.tsx
+++ b/frontend/src/components/layout/panels/MainPanel.tsx
@@ -1,6 +1,9 @@
 import { useExperimentStore } from '@stores/experimentStore'
+import { useMetricsStore } from '@stores/metricsStore'
 import { StatusDot } from '@components/ui/StatusDot/StatusDot'
-import { formatDuration, toExperimentStatus } from '@utils/formatting'
+import { formatDuration, formatStepCount, toExperimentStatus } from '@utils/formatting'
+import { MetricsGrid } from '@components/Experiments/MetricsGrid'
+import { ChartsArea } from '@components/Experiments/ChartsArea'
 
 function FluxBanner() {
   return (
@@ -75,10 +78,25 @@ function FluxBanner() {
   )
 }
 
+function useLatestStep(experimentId: string | null): number | null {
+  const sparklineData = useMetricsStore((s) =>
+    experimentId ? s.sparklineData[experimentId] : undefined
+  )
+  if (!sparklineData) return null
+  let maxStep = 0
+  for (const points of Object.values(sparklineData)) {
+    for (const p of points) {
+      if (p.step > maxStep) maxStep = p.step
+    }
+  }
+  return maxStep > 0 ? maxStep : null
+}
+
 export function MainPanel() {
   const selectedId = useExperimentStore((s) => s.selectedId)
   const experiments = useExperimentStore((s) => s.experiments)
   const selected = experiments.find((e) => e.id === selectedId)
+  const latestStep = useLatestStep(selected?.id ?? null)
 
   if (!selected) {
     return (
@@ -104,10 +122,18 @@ export function MainPanel() {
           <div className="experiment-header__meta">
             <span aria-label={`Duration: ${duration}`}>{duration}</span>
             <span aria-label={`Status: ${status}`}>{status}</span>
+            {latestStep !== null && (
+              <span className="experiment-header__step" data-testid="step-count">
+                Step {formatStepCount(latestStep)}
+              </span>
+            )}
           </div>
         </div>
       </div>
-      <div className="experiment-header__dashboard" />
+      <div className="experiment-header__dashboard">
+        <MetricsGrid experimentId={selected.id} />
+        <ChartsArea />
+      </div>
     </div>
   )
 }

--- a/frontend/src/stores/metricsStore.ts
+++ b/frontend/src/stores/metricsStore.ts
@@ -72,37 +72,27 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
 
   fetchSparklineData: async (experimentId: string) => {
     try {
-      const [lossMetrics, rewardMetrics] = await Promise.all([
-        QueryMetrics(experimentId, 'loss', 0, 0),
-        QueryMetrics(experimentId, 'reward', 0, 0),
-      ])
-
-      if (lossMetrics.length === 0 && rewardMetrics.length === 0) {
-        set((state) => ({
-          sparklineData: {
-            ...state.sparklineData,
-            [experimentId]: {},
-          },
-        }))
-        return
-      }
+      const metricNames = ['loss', 'reward', 'kl', 'learning_rate']
+      const results = await Promise.all(
+        metricNames.map((name) => QueryMetrics(experimentId, name, 0, 0))
+      )
 
       const sparkData: Record<string, Point[]> = {}
+      let hasData = false
 
-      if (lossMetrics.length > 0) {
-        const lossPoints: Point[] = lossMetrics.map((m) => ({ step: m.step, value: m.value }))
-        sparkData['loss'] = downsampleLTTB(lossPoints, 60)
-      }
-
-      if (rewardMetrics.length > 0) {
-        const rewardPoints: Point[] = rewardMetrics.map((m) => ({ step: m.step, value: m.value }))
-        sparkData['reward'] = downsampleLTTB(rewardPoints, 60)
+      for (let i = 0; i < metricNames.length; i++) {
+        const raw = results[i]
+        if (raw.length > 0) {
+          hasData = true
+          const points: Point[] = raw.map((m) => ({ step: m.step, value: m.value }))
+          sparkData[metricNames[i]] = downsampleLTTB(points, 60)
+        }
       }
 
       set((state) => ({
         sparklineData: {
           ...state.sparklineData,
-          [experimentId]: sparkData,
+          [experimentId]: hasData ? sparkData : {},
         },
       }))
     } catch (err) {
@@ -151,26 +141,24 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
 
     const unsubMetrics = EventsOn('metrics:recorded', (data: { experimentId?: string }) => {
       if (!data?.experimentId) return
-      const expId = data.experimentId
+      const key = `metrics:${data.experimentId}`
 
-      if (_debounceTimers[expId]) clearTimeout(_debounceTimers[expId])
-      _debounceTimers[expId] = setTimeout(() => {
-        delete _debounceTimers[expId]
-        get().fetchLatestMetrics(expId)
-        get().fetchSparklineData(expId)
+      if (_debounceTimers[key]) clearTimeout(_debounceTimers[key])
+      _debounceTimers[key] = setTimeout(() => {
+        delete _debounceTimers[key]
+        get().fetchLatestMetrics(data.experimentId!)
+        get().fetchSparklineData(data.experimentId!)
       }, 200)
     })
 
     const unsubRewards = EventsOn('rewards:recorded', (data: { experimentId?: string }) => {
       if (!data?.experimentId) return
-      const expId = data.experimentId
+      const key = `rewards:${data.experimentId}`
 
-      if (_debounceTimers[expId]) clearTimeout(_debounceTimers[expId])
-      _debounceTimers[expId] = setTimeout(() => {
-        delete _debounceTimers[expId]
-        get().fetchLatestMetrics(expId)
-        get().fetchSparklineData(expId)
-        get().fetchLatestRewardSignals(expId)
+      if (_debounceTimers[key]) clearTimeout(_debounceTimers[key])
+      _debounceTimers[key] = setTimeout(() => {
+        delete _debounceTimers[key]
+        get().fetchLatestRewardSignals(data.experimentId!)
       }, 200)
     })
 

--- a/frontend/src/stores/metricsStore.ts
+++ b/frontend/src/stores/metricsStore.ts
@@ -72,7 +72,14 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
 
   fetchSparklineData: async (experimentId: string) => {
     try {
-      const metricNames = ['loss', 'reward', 'kl', 'learning_rate']
+      const metricNames = [
+        'loss',
+        'reward',
+        'kl',
+        'learning_rate',
+        'reward_variance',
+        'policy_entropy',
+      ]
       const results = await Promise.all(
         metricNames.map((name) => QueryMetrics(experimentId, name, 0, 0))
       )

--- a/frontend/src/stores/metricsStore.ts
+++ b/frontend/src/stores/metricsStore.ts
@@ -1,21 +1,30 @@
 import { create } from 'zustand'
-import { GetLatestMetrics, QueryMetrics } from '../../wailsjs/go/main/App'
+import { GetLatestMetrics, QueryMetrics, QueryRewardSignals } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime/runtime'
 import { downsampleLTTB, type Point } from '@utils/downsample'
 
 /** Map of metric name to its latest value */
 type MetricMap = Record<string, number>
 
+export interface LatestRewardSignal {
+  component: string
+  value: number
+  step: number
+}
+
 interface MetricsState {
   /** experimentId -> { metricName -> value } */
   latestMetrics: Record<string, MetricMap>
   /** experimentId -> { metricName -> Point[] } */
   sparklineData: Record<string, Record<string, Point[]>>
+  /** experimentId -> LatestRewardSignal[] */
+  latestRewardSignals: Record<string, LatestRewardSignal[]>
 
   fetchLatestMetrics: (experimentId: string) => Promise<void>
   fetchAllLatestMetrics: (experimentIds: string[]) => Promise<void>
   fetchSparklineData: (experimentId: string) => Promise<void>
   fetchAllSparklineData: (experimentIds: string[]) => Promise<void>
+  fetchLatestRewardSignals: (experimentId: string) => Promise<void>
   initialize: () => void
 }
 
@@ -31,12 +40,13 @@ export function __resetMetricsStore(): void {
     _unsubscribe()
     _unsubscribe = null
   }
-  useMetricsStore.setState({ latestMetrics: {}, sparklineData: {} })
+  useMetricsStore.setState({ latestMetrics: {}, sparklineData: {}, latestRewardSignals: {} })
 }
 
 export const useMetricsStore = create<MetricsState>((set, get) => ({
   latestMetrics: {},
   sparklineData: {},
+  latestRewardSignals: {},
 
   fetchLatestMetrics: async (experimentId: string) => {
     try {
@@ -104,11 +114,42 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
     await Promise.all(experimentIds.map((id) => get().fetchSparklineData(id)))
   },
 
+  fetchLatestRewardSignals: async (experimentId: string) => {
+    try {
+      const results = await QueryRewardSignals(experimentId, '', 0, 0)
+      const latestByComponent = new Map<string, LatestRewardSignal>()
+      for (const s of results) {
+        const existing = latestByComponent.get(s.component)
+        if (!existing || s.step > existing.step) {
+          latestByComponent.set(s.component, {
+            component: s.component,
+            value: s.value,
+            step: s.step,
+          })
+        }
+      }
+      set((state) => ({
+        latestRewardSignals: {
+          ...state.latestRewardSignals,
+          [experimentId]: [...latestByComponent.values()],
+        },
+      }))
+    } catch (err) {
+      console.error(`Failed to fetch reward signals for ${experimentId}:`, err)
+      set((state) => ({
+        latestRewardSignals: {
+          ...state.latestRewardSignals,
+          [experimentId]: [],
+        },
+      }))
+    }
+  },
+
   initialize: () => {
     if (_initialized) return
     _initialized = true
 
-    _unsubscribe = EventsOn('metrics:recorded', (data: { experimentId?: string }) => {
+    const unsubMetrics = EventsOn('metrics:recorded', (data: { experimentId?: string }) => {
       if (!data?.experimentId) return
       const expId = data.experimentId
 
@@ -119,5 +160,23 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
         get().fetchSparklineData(expId)
       }, 200)
     })
+
+    const unsubRewards = EventsOn('rewards:recorded', (data: { experimentId?: string }) => {
+      if (!data?.experimentId) return
+      const expId = data.experimentId
+
+      if (_debounceTimers[expId]) clearTimeout(_debounceTimers[expId])
+      _debounceTimers[expId] = setTimeout(() => {
+        delete _debounceTimers[expId]
+        get().fetchLatestMetrics(expId)
+        get().fetchSparklineData(expId)
+        get().fetchLatestRewardSignals(expId)
+      }, 200)
+    })
+
+    _unsubscribe = () => {
+      unsubMetrics()
+      unsubRewards()
+    }
   },
 }))

--- a/frontend/src/styles/components/layout.css
+++ b/frontend/src/styles/components/layout.css
@@ -513,6 +513,11 @@
   color: var(--color-text-secondary);
 }
 
+.experiment-header__step {
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-medium);
+}
+
 .experiment-header__dashboard {
   display: flex;
   flex-direction: column;

--- a/frontend/src/styles/components/layout.css
+++ b/frontend/src/styles/components/layout.css
@@ -654,6 +654,17 @@
 }
 
 /* ========================================
+ * Metrics Grid
+ * ======================================== */
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+
+/* ========================================
  * Scrollbar
  * ======================================== */
 

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -43,6 +43,7 @@ export function formatDuration(
 const METRIC_DECIMALS: Record<string, number> = {
   loss: 4,
   reward: 3,
+  kl: 6,
 }
 
 /**
@@ -53,6 +54,13 @@ export function formatMetricValue(name: string, value: number | null | undefined
   if (value == null) {
     return '\u2014'
   }
+  if (name === 'learning_rate') {
+    return value.toExponential(2)
+  }
   const decimals = METRIC_DECIMALS[name] ?? 2
   return value.toFixed(decimals)
+}
+
+export function formatStepCount(step: number): string {
+  return step.toLocaleString('en-US')
 }

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -44,6 +44,8 @@ const METRIC_DECIMALS: Record<string, number> = {
   loss: 4,
   reward: 3,
   kl: 6,
+  reward_variance: 4,
+  policy_entropy: 4,
 }
 
 /**

--- a/frontend/src/utils/health.ts
+++ b/frontend/src/utils/health.ts
@@ -1,0 +1,61 @@
+import type { Point } from '@utils/downsample'
+
+export type Trend = 'up' | 'down' | 'flat' | 'insufficient'
+export type HealthStatus = 'healthy' | 'warning' | 'critical' | 'none'
+
+const FLAT_THRESHOLD = 0.01
+const MIN_POINTS = 4
+
+export function computeTrend(data: Point[]): Trend {
+  if (data.length < MIN_POINTS) return 'insufficient'
+
+  const mid = Math.floor(data.length / 2)
+  const prevSlice = data.slice(0, mid)
+  const recentSlice = data.slice(mid)
+
+  const prevAvg = prevSlice.reduce((s, p) => s + p.value, 0) / prevSlice.length
+  const recentAvg = recentSlice.reduce((s, p) => s + p.value, 0) / recentSlice.length
+
+  const denom = Math.abs(prevAvg) > 1e-10 ? Math.abs(prevAvg) : 1
+  const relativeChange = (recentAvg - prevAvg) / denom
+
+  if (Math.abs(relativeChange) <= FLAT_THRESHOLD) return 'flat'
+  return relativeChange > 0 ? 'up' : 'down'
+}
+
+type HealthRule = Record<Exclude<Trend, 'insufficient'>, HealthStatus>
+
+const HEALTH_RULES: Record<string, HealthRule> = {
+  loss: { down: 'healthy', flat: 'warning', up: 'critical' },
+  reward: { up: 'healthy', flat: 'warning', down: 'critical' },
+  kl: { flat: 'healthy', up: 'warning', down: 'healthy' },
+}
+
+export function assessHealth(metricName: string, trend: Trend): HealthStatus {
+  if (trend === 'insufficient') return 'none'
+  const rule = HEALTH_RULES[metricName]
+  if (!rule) return 'none'
+  return rule[trend]
+}
+
+interface RewardComponent {
+  name: string
+  value: number
+}
+
+const DIVERGENCE_RATIO = 2.0
+const DIVERGENCE_MIN_SPREAD = 0.1
+
+export function assessRewardDivergence(components: RewardComponent[]): HealthStatus {
+  if (components.length === 0) return 'none'
+
+  const values = components.map((c) => c.value)
+  const max = Math.max(...values)
+  const min = Math.min(...values)
+
+  if (max - min < DIVERGENCE_MIN_SPREAD) return 'healthy'
+  if (min > 0 && max / min > DIVERGENCE_RATIO) return 'warning'
+  if (min <= 0 && max - min > DIVERGENCE_MIN_SPREAD) return 'warning'
+
+  return 'healthy'
+}

--- a/frontend/src/utils/health.ts
+++ b/frontend/src/utils/health.ts
@@ -29,6 +29,8 @@ const HEALTH_RULES: Record<string, HealthRule> = {
   loss: { down: 'healthy', flat: 'warning', up: 'critical' },
   reward: { up: 'healthy', flat: 'warning', down: 'critical' },
   kl: { flat: 'healthy', up: 'warning', down: 'healthy' },
+  reward_variance: { flat: 'healthy', down: 'warning', up: 'healthy' },
+  policy_entropy: { flat: 'healthy', down: 'warning', up: 'warning' },
 }
 
 export function assessHealth(metricName: string, trend: Trend): HealthStatus {

--- a/frontend/src/utils/health.ts
+++ b/frontend/src/utils/health.ts
@@ -49,13 +49,13 @@ const DIVERGENCE_MIN_SPREAD = 0.1
 export function assessRewardDivergence(components: RewardComponent[]): HealthStatus {
   if (components.length === 0) return 'none'
 
-  const values = components.map((c) => c.value)
-  const max = Math.max(...values)
-  const min = Math.min(...values)
+  const absValues = components.map((c) => Math.abs(c.value))
+  const maxAbs = Math.max(...absValues)
+  const minAbs = Math.min(...absValues)
+  const spread = maxAbs - minAbs
 
-  if (max - min < DIVERGENCE_MIN_SPREAD) return 'healthy'
-  if (min > 0 && max / min > DIVERGENCE_RATIO) return 'warning'
-  if (min <= 0 && max - min > DIVERGENCE_MIN_SPREAD) return 'warning'
+  if (spread < DIVERGENCE_MIN_SPREAD) return 'healthy'
+  if (minAbs > 1e-10 && maxAbs / minAbs > DIVERGENCE_RATIO) return 'warning'
 
   return 'healthy'
 }

--- a/frontend/src/utils/health.ts
+++ b/frontend/src/utils/health.ts
@@ -61,3 +61,80 @@ export function assessRewardDivergence(components: RewardComponent[]): HealthSta
 
   return 'healthy'
 }
+
+export type DetectionLevel = 'clear' | 'monitoring' | 'elevated' | 'detected'
+
+export interface DetectionResult {
+  pattern: string
+  status: DetectionLevel
+  confidence: number | null
+}
+
+interface MetricTrends {
+  kl?: Trend
+  reward?: Trend
+  reward_variance?: Trend
+  policy_entropy?: Trend
+}
+
+/**
+ * Derives reward hack detection statuses from metric trends and reward components.
+ * Uses cross-metric correlation to identify the 4 hack patterns:
+ * - Length Gaming: reward up + reward_variance down (reward concentrating)
+ * - Sycophancy: KL rising + entropy dropping (model becoming deterministic)
+ * - KL Drift: KL rising on its own
+ * - Reward Collapse: reward_variance dropping sharply
+ */
+export function deriveDetections(
+  trends: MetricTrends,
+  rewardComponents: RewardComponent[]
+): DetectionResult[] {
+  const divergence = assessRewardDivergence(rewardComponents)
+
+  // Length Gaming: reward increasing while variance drops
+  const lengthGaming = derivePatternStatus(
+    trends.reward === 'up' && trends.reward_variance === 'down'
+      ? 'elevated'
+      : trends.reward_variance === 'down'
+        ? 'monitoring'
+        : 'clear'
+  )
+
+  // Sycophancy: KL rising + entropy dropping = model becoming deterministic
+  const sycophancy = derivePatternStatus(
+    trends.kl === 'up' && trends.policy_entropy === 'down'
+      ? 'elevated'
+      : trends.policy_entropy === 'down'
+        ? 'monitoring'
+        : 'clear'
+  )
+
+  // KL Drift: KL divergence trending up
+  const klDrift = derivePatternStatus(trends.kl === 'up' ? 'monitoring' : 'clear')
+
+  // Reward Collapse: variance dropping + component divergence
+  const rewardCollapse = derivePatternStatus(
+    trends.reward_variance === 'down' && divergence === 'warning'
+      ? 'elevated'
+      : divergence === 'warning'
+        ? 'monitoring'
+        : trends.reward_variance === 'down'
+          ? 'monitoring'
+          : 'clear'
+  )
+
+  return [
+    { pattern: 'Length Gaming', ...lengthGaming },
+    { pattern: 'Sycophancy', ...sycophancy },
+    { pattern: 'KL Drift', ...klDrift },
+    { pattern: 'Reward Collapse', ...rewardCollapse },
+  ]
+}
+
+function derivePatternStatus(level: DetectionLevel): {
+  status: DetectionLevel
+  confidence: number | null
+} {
+  // Confidence is null until the alerts backend provides real values
+  return { status: level, confidence: null }
+}

--- a/internal/metrics/seed.go
+++ b/internal/metrics/seed.go
@@ -48,42 +48,101 @@ func (s *Store) SeedDemoMetrics() error {
 
 	for _, exp := range experiments {
 		var metrics []Metric
+		var signals []RewardSignal
 
 		// Status strings match experiment.Status* constants but are inlined here
 		// to avoid importing the experiment package (would create a circular dependency).
 		switch exp.Status {
 		case "running":
-			// Running experiments: loss decreasing, reward increasing over ~50 steps
+			// Running experiments: ~50 steps of healthy training
 			for step := int64(1); step <= 50; step++ {
-				loss := 2.5 * math.Exp(-0.03*float64(step))
-				reward := 0.8 * (1 - math.Exp(-0.05*float64(step)))
 				ts := now - (50-step)*60
+				t := float64(step)
+
+				loss := 2.5 * math.Exp(-0.03*t)
+				reward := 0.8 * (1 - math.Exp(-0.05*t))
+				kl := 0.01 + 0.0008*t + 0.0001*math.Sin(t*0.3)
+				lr := 3e-4 * math.Exp(-0.002*t)
+				rewardVar := 0.05 * math.Exp(-0.015*t) + 0.008
+				entropy := 4.5 - 0.02*t + 0.05*math.Sin(t*0.2)
+
 				metrics = append(metrics,
-					Metric{Step: step, Name: "loss", Value: math.Round(loss*10000) / 10000, Timestamp: ts},
-					Metric{Step: step, Name: "reward", Value: math.Round(reward*1000) / 1000, Timestamp: ts},
+					Metric{Step: step, Name: "loss", Value: round(loss, 4), Timestamp: ts},
+					Metric{Step: step, Name: "reward", Value: round(reward, 3), Timestamp: ts},
+					Metric{Step: step, Name: "kl", Value: round(kl, 6), Timestamp: ts},
+					Metric{Step: step, Name: "learning_rate", Value: round(lr, 8), Timestamp: ts},
+					Metric{Step: step, Name: "reward_variance", Value: round(rewardVar, 4), Timestamp: ts},
+					Metric{Step: step, Name: "policy_entropy", Value: round(entropy, 4), Timestamp: ts},
 				)
+
+				// Reward signals every 5 steps
+				if step%5 == 0 {
+					signals = append(signals,
+						RewardSignal{Step: step, Component: "helpfulness", Value: round(0.6+0.004*t, 3)},
+						RewardSignal{Step: step, Component: "harmlessness", Value: round(0.7+0.002*t, 3)},
+						RewardSignal{Step: step, Component: "honesty", Value: round(0.65+0.003*t, 3)},
+					)
+				}
 			}
 		case "completed":
 			// Completed experiments: full training run of 100 steps
 			for step := int64(1); step <= 100; step++ {
-				loss := 2.0 * math.Exp(-0.04*float64(step))
-				reward := 0.9 * (1 - math.Exp(-0.06*float64(step)))
 				ts := now - 3600*4 + step*144
+				t := float64(step)
+
+				loss := 2.0 * math.Exp(-0.04*t)
+				reward := 0.9 * (1 - math.Exp(-0.06*t))
+				kl := 0.02 + 0.0005*t + 0.00015*math.Sin(t*0.2)
+				lr := 5e-4 * math.Exp(-0.003*t)
+				rewardVar := 0.08 * math.Exp(-0.02*t) + 0.005
+				entropy := 4.8 - 0.025*t + 0.04*math.Sin(t*0.15)
+
 				metrics = append(metrics,
-					Metric{Step: step, Name: "loss", Value: math.Round(loss*10000) / 10000, Timestamp: ts},
-					Metric{Step: step, Name: "reward", Value: math.Round(reward*1000) / 1000, Timestamp: ts},
+					Metric{Step: step, Name: "loss", Value: round(loss, 4), Timestamp: ts},
+					Metric{Step: step, Name: "reward", Value: round(reward, 3), Timestamp: ts},
+					Metric{Step: step, Name: "kl", Value: round(kl, 6), Timestamp: ts},
+					Metric{Step: step, Name: "learning_rate", Value: round(lr, 8), Timestamp: ts},
+					Metric{Step: step, Name: "reward_variance", Value: round(rewardVar, 4), Timestamp: ts},
+					Metric{Step: step, Name: "policy_entropy", Value: round(entropy, 4), Timestamp: ts},
 				)
+
+				if step%10 == 0 {
+					signals = append(signals,
+						RewardSignal{Step: step, Component: "helpfulness", Value: round(0.5+0.004*t, 3)},
+						RewardSignal{Step: step, Component: "harmlessness", Value: round(0.6+0.003*t, 3)},
+						RewardSignal{Step: step, Component: "honesty", Value: round(0.55+0.0035*t, 3)},
+					)
+				}
 			}
 		case "failed":
-			// Failed experiments: only partial data (20 steps), loss starts diverging
+			// Failed experiments: 20 steps, loss diverges, entropy collapses
 			for step := int64(1); step <= 20; step++ {
-				loss := 2.5 - 0.05*float64(step) + 0.01*float64(step*step)
-				reward := 0.1 + 0.02*float64(step) - 0.003*float64(step*step)
 				ts := now - 3600*12 + step*36
+				t := float64(step)
+
+				loss := 2.5 - 0.05*t + 0.01*t*t
+				reward := 0.1 + 0.02*t - 0.003*t*t
+				kl := 0.03 + 0.005*t + 0.001*t*t
+				lr := 1e-3 * math.Exp(-0.01*t)
+				rewardVar := 0.06 * math.Exp(-0.08*t) + 0.001
+				entropy := 4.0 - 0.15*t
+
 				metrics = append(metrics,
-					Metric{Step: step, Name: "loss", Value: math.Round(loss*10000) / 10000, Timestamp: ts},
-					Metric{Step: step, Name: "reward", Value: math.Round(reward*1000) / 1000, Timestamp: ts},
+					Metric{Step: step, Name: "loss", Value: round(loss, 4), Timestamp: ts},
+					Metric{Step: step, Name: "reward", Value: round(reward, 3), Timestamp: ts},
+					Metric{Step: step, Name: "kl", Value: round(kl, 6), Timestamp: ts},
+					Metric{Step: step, Name: "learning_rate", Value: round(lr, 8), Timestamp: ts},
+					Metric{Step: step, Name: "reward_variance", Value: round(rewardVar, 4), Timestamp: ts},
+					Metric{Step: step, Name: "policy_entropy", Value: round(entropy, 4), Timestamp: ts},
 				)
+
+				if step%5 == 0 {
+					signals = append(signals,
+						RewardSignal{Step: step, Component: "helpfulness", Value: round(0.3+0.01*t, 3)},
+						RewardSignal{Step: step, Component: "harmlessness", Value: round(0.4-0.005*t, 3)},
+						RewardSignal{Step: step, Component: "honesty", Value: round(0.35+0.002*t, 3)},
+					)
+				}
 			}
 		default:
 			// Pending experiments: no metrics
@@ -95,7 +154,17 @@ func (s *Store) SeedDemoMetrics() error {
 				return err
 			}
 		}
+		if len(signals) > 0 {
+			if err := s.RecordRewardSignals(exp.ID, signals); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
+}
+
+func round(v float64, decimals int) float64 {
+	pow := math.Pow(10, float64(decimals))
+	return math.Round(v*pow) / pow
 }


### PR DESCRIPTION
## Summary
- Build experiment detail view layout in MainPanel with header (name, status, duration, step count), metrics grid, and charts area
- 4 diagnostic metric cards (KL Divergence, Learning Rate, Reward Variance, Policy Entropy) with inline SVG sparklines, trend percentages, health dots with glow animation, and "from X at start" subtitles
- Reward Hack Detection card with cross-metric correlation detecting 4 patterns: Length Gaming, Sycophancy, KL Drift, Reward Collapse
- Health utilities: windowed trend computation, trend-based health thresholds, reward divergence detection with absolute-value handling
- Charts area with 3 workflow-oriented tabs (Overview, Reward Components, Diagnostics) as Phase 3 placeholders
- Expanded seed data generating all 6 metrics + reward signals for demo experiments

## Test plan
- [x] 264 tests passing across 24 suites (30 new tests added)
- [x] Health utilities: computeTrend, assessHealth, assessRewardDivergence, deriveDetections (30 tests)
- [x] MetricCard: sparkline rendering, trend percentage, subtitle, health states (16 tests)
- [x] RewardHackStatusCard: 4 detection patterns, status labels, confidence, health borders (13 tests)
- [x] MetricsGrid: diagnostic quartet rendering, hack status card (3 tests)
- [x] ChartsArea: tab rendering and switching (4 tests)
- [x] MainPanel: metrics grid integration, step count display (9 tests)
- [x] Go backend compiles and all 75 tests pass
- [x] ESLint + Prettier pass via pre-commit hooks

Generated with [Claude Code](https://claude.com/claude-code)