### PR TITLE
feat: live data updates for reward component charts (#32)

### DIFF
--- a/docs/tdd/032-live-data-updates.md
+++ b/docs/tdd/032-live-data-updates.md
@@ -1,0 +1,91 @@
+# TDD: Issue #32 - Live Data Updates for Charts
+
+## Issue Summary
+Complete the live data update pipeline for all chart types. The Overview chart already updates via `metrics:recorded` events. This issue adds reward component time-series data to the Reward Components tab via `rewards:recorded` events, rendered with the existing `MultiLineChart` component.
+
+## Acceptance Criteria
+- [x] `fetchRewardComponentChartData` method in metricsStore builds AlignedData for helpfulness/harmlessness/honesty
+- [x] Reward component chart data uses union step axis with null-fill for missing values
+- [x] `rewards:recorded` event triggers reward component chart data re-fetch (200ms debounce)
+- [x] Reward Components tab renders MultiLineChart when data is available
+- [x] Reward Components tab shows placeholder when no data exists
+- [x] `__resetMetricsStore` clears reward component chart data
+
+## Rationale
+The reward components chart completes the live visualization pipeline. By reusing `MultiLineChart` and the existing event-driven architecture, we maintain consistency with the Overview chart pattern while adding no new component code.
+
+Design decisions:
+- **Hardcoded component names** (`helpfulness`, `harmlessness`, `honesty`) — matches the pattern in `fetchSparklineData` which hardcodes 6 metric names. Dynamic discovery would cause non-deterministic series ordering.
+- **Diagnostics tab stays as placeholder** — out of scope for #32.
+
+## Failing Tests
+
+### metricsStore tests (4 new)
+
+| Test | Description |
+|------|-------------|
+| `fetchRewardComponentChartData populates aligned data` | Seed 3 components at steps 10, 20, 30 → assert AlignedData shape `[steps, help, harm, honest]` |
+| `fetchRewardComponentChartData null-fills missing steps` | Components at different steps → assert null where missing |
+| `fetchRewardComponentChartData returns empty arrays when no data` | Assert `[[], [], [], []]` |
+| `rewards:recorded triggers reward component chart data re-fetch` | Seed → initialize → emit event → advance timer → assert updated data |
+
+### ChartsArea tests (2 new)
+
+| Test | Description |
+|------|-------------|
+| `renders MultiLineChart in Reward Components tab when data available` | Seed reward signals, fetch, click tab → assert `data-testid="multiline-chart"` |
+| `shows placeholder in Reward Components tab when no data` | No seed, click tab → assert placeholder text |
+
+## Expected Output (Failing)
+
+```
+FAIL metricsStore.test.ts
+  ✕ fetchRewardComponentChartData populates aligned data
+  ✕ fetchRewardComponentChartData null-fills missing steps
+  ✕ fetchRewardComponentChartData returns empty arrays when no data
+  ✕ rewards:recorded triggers reward component chart data re-fetch
+
+FAIL ChartsArea.test.tsx
+  ✕ renders MultiLineChart in Reward Components tab when data available
+  ✕ shows placeholder in Reward Components tab when no data
+```
+
+## Test Summary
+
+| Suite | Existing | New | Total |
+|-------|----------|-----|-------|
+| metricsStore | 12 | 4 | 16 |
+| ChartsArea | 6 | 2 | 8 |
+| **Total** | **18** | **6** | **24** |
+
+## Passing Test Results
+
+```
+PASS src/__tests__/stores/metricsStore.test.ts
+PASS src/__tests__/components/Experiments/ChartsArea.test.tsx
+
+Test Suites: 2 passed, 2 total
+Tests:       25 passed, 25 total
+```
+
+Full suite: 31 suites, 319 tests, all passing.
+
+## Implementation Summary
+
+### metricsStore.ts
+- Added `rewardComponentChartData: Record<string, AlignedData>` to state interface and initial state
+- Added `fetchRewardComponentChartData(experimentId)` method that:
+  - Calls `QueryRewardSignals(experimentId, '', 0, 0)` to get all signals
+  - Groups results by component (`helpfulness`, `harmlessness`, `honesty`) into step→value Maps
+  - Builds union step axis from all components
+  - Null-fills missing values per component
+  - Produces `AlignedData: [steps[], helpfulness[], harmlessness[], honesty[]]`
+- Updated `rewards:recorded` event handler to call `fetchRewardComponentChartData` alongside `fetchLatestRewardSignals`
+- Updated `__resetMetricsStore` to clear `rewardComponentChartData`
+
+### ChartsArea.tsx
+- Imported `MultiLineChart` from `@components/Charts`
+- Defined static constants outside component: `REWARD_COMPONENT_LABELS` and `REWARD_COMPONENT_COLORS`
+- Added store selectors for `rewardComponentChartData` and `fetchRewardComponentChartData`
+- Extended `useEffect` to fetch reward component data on experiment change
+- Expanded render logic: Overview → TimeSeriesChart, Reward Components → MultiLineChart, else → placeholder

--- a/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { ChartsArea } from '@components/Experiments/ChartsArea'
 import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
-import { __resetMockState, RecordMetrics } from '../../../__mocks__/wailsjs/go/main/App'
+import {
+  __resetMockState,
+  RecordMetrics,
+  RecordRewardSignals,
+} from '../../../__mocks__/wailsjs/go/main/App'
 import { metrics } from '../../../__mocks__/wailsjs/go/models'
 
 // Mock uPlot (same pattern as TimeSeriesChart test)
@@ -117,5 +121,46 @@ describe('ChartsArea', () => {
     render(<ChartsArea experimentId="exp-1" />)
     fireEvent.click(screen.getByText('Reward Components'))
     expect(screen.queryByTestId('timeseries-chart')).not.toBeInTheDocument()
+  })
+
+  it('renders MultiLineChart in Reward Components tab when data available', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.8,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'harmlessness',
+        value: 0.7,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'honesty',
+        value: 0.75,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchRewardComponentChartData('exp-1')
+    })
+
+    render(<ChartsArea experimentId="exp-1" />)
+    fireEvent.click(screen.getByText('Reward Components'))
+    expect(screen.getByTestId('multiline-chart')).toBeInTheDocument()
+  })
+
+  it('shows placeholder in Reward Components tab when no data', () => {
+    render(<ChartsArea experimentId="exp-empty" />)
+    fireEvent.click(screen.getByText('Reward Components'))
+    expect(screen.getByText('No metrics data yet')).toBeInTheDocument()
+    expect(screen.queryByTestId('multiline-chart')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/stores/metricsStore.test.ts
+++ b/frontend/src/__tests__/stores/metricsStore.test.ts
@@ -377,6 +377,159 @@ describe('reward signal support', () => {
   })
 })
 
+describe('reward component chart data', () => {
+  it('fetchRewardComponentChartData populates aligned data', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.8,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'helpfulness',
+        value: 0.85,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 30,
+        component: 'helpfulness',
+        value: 0.9,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'harmlessness',
+        value: 0.7,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'harmlessness',
+        value: 0.74,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 30,
+        component: 'harmlessness',
+        value: 0.78,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'honesty',
+        value: 0.75,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'honesty',
+        value: 0.79,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 30,
+        component: 'honesty',
+        value: 0.83,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchRewardComponentChartData('exp-1')
+    })
+
+    const data = useMetricsStore.getState().rewardComponentChartData['exp-1']
+    expect(data).toBeDefined()
+    expect(data).toHaveLength(4) // [steps, helpfulness, harmlessness, honesty]
+    expect(data[0]).toEqual([10, 20, 30])
+    expect(data[1]).toEqual([0.8, 0.85, 0.9]) // helpfulness
+    expect(data[2]).toEqual([0.7, 0.74, 0.78]) // harmlessness
+    expect(data[3]).toEqual([0.75, 0.79, 0.83]) // honesty
+  })
+
+  it('fetchRewardComponentChartData null-fills missing steps', async () => {
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.8,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 30,
+        component: 'helpfulness',
+        value: 0.9,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'harmlessness',
+        value: 0.74,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'honesty',
+        value: 0.75,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'honesty',
+        value: 0.79,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 30,
+        component: 'honesty',
+        value: 0.83,
+        distribution: '',
+      }),
+    ])
+
+    await act(async () => {
+      await useMetricsStore.getState().fetchRewardComponentChartData('exp-1')
+    })
+
+    const data = useMetricsStore.getState().rewardComponentChartData['exp-1']
+    expect(data[0]).toEqual([10, 20, 30]) // union of all steps
+    expect(data[1]).toEqual([0.8, null, 0.9]) // helpfulness: missing at step 20
+    expect(data[2]).toEqual([null, 0.74, null]) // harmlessness: only at step 20
+    expect(data[3]).toEqual([0.75, 0.79, 0.83]) // honesty: all steps
+  })
+
+  it('fetchRewardComponentChartData returns empty arrays when no data', async () => {
+    await act(async () => {
+      await useMetricsStore.getState().fetchRewardComponentChartData('exp-empty')
+    })
+
+    const data = useMetricsStore.getState().rewardComponentChartData['exp-empty']
+    expect(data).toBeDefined()
+    expect(data).toHaveLength(4)
+    expect(data[0]).toEqual([])
+    expect(data[1]).toEqual([])
+    expect(data[2]).toEqual([])
+    expect(data[3]).toEqual([])
+  })
+})
+
 describe('live updates', () => {
   beforeEach(() => {
     jest.useFakeTimers()
@@ -449,5 +602,84 @@ describe('live updates', () => {
     expect(updatedData[0]).toEqual([1, 2]) // now 2 steps
     expect(updatedData[1]).toEqual([2.5, 1.8]) // loss values
     expect(updatedData[2]).toEqual([0.1, 0.5]) // reward values
+  })
+
+  it('rewards:recorded triggers reward component chart data re-fetch', async () => {
+    // Seed initial reward signals
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'helpfulness',
+        value: 0.8,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'harmlessness',
+        value: 0.7,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 10,
+        component: 'honesty',
+        value: 0.75,
+        distribution: '',
+      }),
+    ])
+
+    // Initialize store (sets up event listeners)
+    useMetricsStore.getState().initialize()
+
+    // Fetch initial data
+    await act(async () => {
+      await useMetricsStore.getState().fetchRewardComponentChartData('exp-1')
+    })
+
+    const initialData = useMetricsStore.getState().rewardComponentChartData['exp-1']
+    expect(initialData[0]).toEqual([10]) // 1 step
+
+    // Add new reward signals
+    await RecordRewardSignals('exp-1', [
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'helpfulness',
+        value: 0.85,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'harmlessness',
+        value: 0.74,
+        distribution: '',
+      }),
+      new metrics.RewardSignal({
+        experiment_id: 'exp-1',
+        step: 20,
+        component: 'honesty',
+        value: 0.79,
+        distribution: '',
+      }),
+    ])
+
+    // Simulate the event
+    EventsEmit('rewards:recorded', { experimentId: 'exp-1' })
+
+    // Advance past the 200ms debounce
+    await act(async () => {
+      jest.advanceTimersByTime(300)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const updatedData = useMetricsStore.getState().rewardComponentChartData['exp-1']
+    expect(updatedData[0]).toEqual([10, 20]) // now 2 steps
+    expect(updatedData[1]).toEqual([0.8, 0.85]) // helpfulness
+    expect(updatedData[2]).toEqual([0.7, 0.74]) // harmlessness
+    expect(updatedData[3]).toEqual([0.75, 0.79]) // honesty
   })
 })

--- a/frontend/src/components/Experiments/ChartsArea.tsx
+++ b/frontend/src/components/Experiments/ChartsArea.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { LineChart } from 'lucide-react'
 import './ChartsArea.css'
 import { useMetricsStore } from '@stores'
-import { TimeSeriesChart, CHART_COLORS } from '@components/Charts'
+import { TimeSeriesChart, MultiLineChart, CHART_COLORS } from '@components/Charts'
 import type { Options } from 'uplot'
 
 const TABS = ['Overview', 'Reward Components', 'Diagnostics'] as const
@@ -22,6 +22,13 @@ const CHART_SERIES: Options['series'] = [
   },
 ]
 
+const REWARD_COMPONENT_LABELS = ['Helpfulness', 'Harmlessness', 'Honesty']
+const REWARD_COMPONENT_COLORS = [
+  CHART_COLORS.palette[0],
+  CHART_COLORS.palette[1],
+  CHART_COLORS.palette[2],
+]
+
 interface ChartsAreaProps {
   experimentId: string
 }
@@ -32,12 +39,42 @@ export function ChartsArea({ experimentId }: ChartsAreaProps) {
   const chartData = useMetricsStore((state) => state.chartData[experimentId])
   const fetchChartData = useMetricsStore((state) => state.fetchChartData)
 
+  const rewardComponentChartData = useMetricsStore(
+    (state) => state.rewardComponentChartData[experimentId]
+  )
+  const fetchRewardComponentChartData = useMetricsStore(
+    (state) => state.fetchRewardComponentChartData
+  )
+
   // Fetch chart data when experiment changes
   useEffect(() => {
     fetchChartData(experimentId)
-  }, [experimentId, fetchChartData])
+    fetchRewardComponentChartData(experimentId)
+  }, [experimentId, fetchChartData, fetchRewardComponentChartData])
 
-  const hasData = chartData && chartData[0]?.length > 0
+  const hasOverviewData = chartData && chartData[0]?.length > 0
+  const hasRewardComponentData = rewardComponentChartData && rewardComponentChartData[0]?.length > 0
+
+  const renderContent = () => {
+    if (activeTab === 'Overview' && hasOverviewData) {
+      return <TimeSeriesChart data={chartData} series={CHART_SERIES} />
+    }
+    if (activeTab === 'Reward Components' && hasRewardComponentData) {
+      return (
+        <MultiLineChart
+          data={rewardComponentChartData}
+          seriesLabels={REWARD_COMPONENT_LABELS}
+          seriesColors={REWARD_COMPONENT_COLORS}
+        />
+      )
+    }
+    return (
+      <div className="charts-area__placeholder">
+        <LineChart className="charts-area__placeholder-icon" />
+        <span className="charts-area__placeholder-text">No metrics data yet</span>
+      </div>
+    )
+  }
 
   return (
     <div className="charts-area">
@@ -52,14 +89,7 @@ export function ChartsArea({ experimentId }: ChartsAreaProps) {
           </button>
         ))}
       </div>
-      {activeTab === 'Overview' && hasData ? (
-        <TimeSeriesChart data={chartData} series={CHART_SERIES} />
-      ) : (
-        <div className="charts-area__placeholder">
-          <LineChart className="charts-area__placeholder-icon" />
-          <span className="charts-area__placeholder-text">No metrics data yet</span>
-        </div>
-      )}
+      {renderContent()}
     </div>
   )
 }

--- a/frontend/src/stores/metricsStore.ts
+++ b/frontend/src/stores/metricsStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { create, type StoreApi } from 'zustand'
 import { GetLatestMetrics, QueryMetrics, QueryRewardSignals } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime/runtime'
 import { downsampleLTTB, type Point } from '@utils/downsample'
@@ -36,6 +36,82 @@ interface MetricsState {
 let _initialized = false
 let _debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {}
 let _unsubscribe: (() => void) | null = null
+
+const REWARD_COMPONENTS = ['helpfulness', 'harmlessness', 'honesty'] as const
+
+/**
+ * Queries reward signals once and updates both latestRewardSignals and
+ * rewardComponentChartData, avoiding duplicate backend calls.
+ */
+async function _fetchAllRewardData(
+  experimentId: string,
+  set: StoreApi<MetricsState>['setState']
+): Promise<void> {
+  try {
+    const results = await QueryRewardSignals(experimentId, '', 0, 0)
+
+    // --- Derive latestRewardSignals ---
+    const latestByComponent = new Map<string, LatestRewardSignal>()
+    for (const s of results) {
+      const existing = latestByComponent.get(s.component)
+      if (!existing || s.step > existing.step) {
+        latestByComponent.set(s.component, {
+          component: s.component,
+          value: s.value,
+          step: s.step,
+        })
+      }
+    }
+
+    // --- Derive rewardComponentChartData ---
+    let chartData: AlignedData = [[], [], [], []]
+    if (results.length > 0) {
+      const componentMaps = new Map<string, Map<number, number>>()
+      for (const name of REWARD_COMPONENTS) componentMaps.set(name, new Map())
+
+      for (const s of results) {
+        const map = componentMaps.get(s.component)
+        if (map) map.set(s.step, s.value)
+      }
+
+      const stepSet = new Set<number>()
+      for (const map of componentMaps.values()) {
+        for (const step of map.keys()) stepSet.add(step)
+      }
+      const steps = [...stepSet].sort((a, b) => a - b)
+
+      const aligned = REWARD_COMPONENTS.map((name) => {
+        const map = componentMaps.get(name)!
+        return steps.map((s) => map.get(s) ?? null)
+      })
+      chartData = [steps, ...aligned]
+    }
+
+    // --- Set both slices in a single state update ---
+    set((state: MetricsState) => ({
+      latestRewardSignals: {
+        ...state.latestRewardSignals,
+        [experimentId]: [...latestByComponent.values()],
+      },
+      rewardComponentChartData: {
+        ...state.rewardComponentChartData,
+        [experimentId]: chartData,
+      },
+    }))
+  } catch (err) {
+    console.error(`Failed to fetch reward data for ${experimentId}:`, err)
+    set((state: MetricsState) => ({
+      latestRewardSignals: {
+        ...state.latestRewardSignals,
+        [experimentId]: [],
+      },
+      rewardComponentChartData: {
+        ...state.rewardComponentChartData,
+        [experimentId]: [[], [], [], []],
+      },
+    }))
+  }
+}
 
 export function __resetMetricsStore(): void {
   _initialized = false
@@ -197,7 +273,6 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
   },
 
   fetchRewardComponentChartData: async (experimentId: string) => {
-    const COMPONENTS = ['helpfulness', 'harmlessness', 'honesty'] as const
     try {
       const results = await QueryRewardSignals(experimentId, '', 0, 0)
 
@@ -213,7 +288,7 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
 
       // Group by component: Map<component, Map<step, value>>
       const componentMaps = new Map<string, Map<number, number>>()
-      for (const name of COMPONENTS) componentMaps.set(name, new Map())
+      for (const name of REWARD_COMPONENTS) componentMaps.set(name, new Map())
 
       for (const s of results) {
         const map = componentMaps.get(s.component)
@@ -228,7 +303,7 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
       const steps = [...stepSet].sort((a, b) => a - b)
 
       // Build aligned arrays with null-fill
-      const aligned = COMPONENTS.map((name) => {
+      const aligned = REWARD_COMPONENTS.map((name) => {
         const map = componentMaps.get(name)!
         return steps.map((s) => map.get(s) ?? null)
       })
@@ -241,6 +316,12 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
       }))
     } catch (err) {
       console.error(`Failed to fetch reward component chart data for ${experimentId}:`, err)
+      set((state) => ({
+        rewardComponentChartData: {
+          ...state.rewardComponentChartData,
+          [experimentId]: [[], [], [], []],
+        },
+      }))
     }
   },
 
@@ -268,8 +349,7 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
       if (_debounceTimers[key]) clearTimeout(_debounceTimers[key])
       _debounceTimers[key] = setTimeout(() => {
         delete _debounceTimers[key]
-        get().fetchLatestRewardSignals(data.experimentId!)
-        get().fetchRewardComponentChartData(data.experimentId!)
+        _fetchAllRewardData(data.experimentId!, set)
       }, 200)
     })
 

--- a/frontend/src/stores/metricsStore.ts
+++ b/frontend/src/stores/metricsStore.ts
@@ -21,6 +21,7 @@ interface MetricsState {
   /** experimentId -> LatestRewardSignal[] */
   latestRewardSignals: Record<string, LatestRewardSignal[]>
   chartData: Record<string, AlignedData>
+  rewardComponentChartData: Record<string, AlignedData>
 
   fetchLatestMetrics: (experimentId: string) => Promise<void>
   fetchAllLatestMetrics: (experimentIds: string[]) => Promise<void>
@@ -28,6 +29,7 @@ interface MetricsState {
   fetchAllSparklineData: (experimentIds: string[]) => Promise<void>
   fetchLatestRewardSignals: (experimentId: string) => Promise<void>
   fetchChartData: (experimentId: string) => Promise<void>
+  fetchRewardComponentChartData: (experimentId: string) => Promise<void>
   initialize: () => void
 }
 
@@ -48,6 +50,7 @@ export function __resetMetricsStore(): void {
     sparklineData: {},
     latestRewardSignals: {},
     chartData: {},
+    rewardComponentChartData: {},
   })
 }
 
@@ -56,6 +59,7 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
   sparklineData: {},
   latestRewardSignals: {},
   chartData: {},
+  rewardComponentChartData: {},
 
   fetchLatestMetrics: async (experimentId: string) => {
     try {
@@ -192,6 +196,54 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
     }
   },
 
+  fetchRewardComponentChartData: async (experimentId: string) => {
+    const COMPONENTS = ['helpfulness', 'harmlessness', 'honesty'] as const
+    try {
+      const results = await QueryRewardSignals(experimentId, '', 0, 0)
+
+      if (results.length === 0) {
+        set((state) => ({
+          rewardComponentChartData: {
+            ...state.rewardComponentChartData,
+            [experimentId]: [[], [], [], []],
+          },
+        }))
+        return
+      }
+
+      // Group by component: Map<component, Map<step, value>>
+      const componentMaps = new Map<string, Map<number, number>>()
+      for (const name of COMPONENTS) componentMaps.set(name, new Map())
+
+      for (const s of results) {
+        const map = componentMaps.get(s.component)
+        if (map) map.set(s.step, s.value)
+      }
+
+      // Build union step axis
+      const stepSet = new Set<number>()
+      for (const map of componentMaps.values()) {
+        for (const step of map.keys()) stepSet.add(step)
+      }
+      const steps = [...stepSet].sort((a, b) => a - b)
+
+      // Build aligned arrays with null-fill
+      const aligned = COMPONENTS.map((name) => {
+        const map = componentMaps.get(name)!
+        return steps.map((s) => map.get(s) ?? null)
+      })
+
+      set((state) => ({
+        rewardComponentChartData: {
+          ...state.rewardComponentChartData,
+          [experimentId]: [steps, ...aligned],
+        },
+      }))
+    } catch (err) {
+      console.error(`Failed to fetch reward component chart data for ${experimentId}:`, err)
+    }
+  },
+
   initialize: () => {
     if (_initialized) return
     _initialized = true
@@ -217,6 +269,7 @@ export const useMetricsStore = create<MetricsState>((set, get) => ({
       _debounceTimers[key] = setTimeout(() => {
         delete _debounceTimers[key]
         get().fetchLatestRewardSignals(data.experimentId!)
+        get().fetchRewardComponentChartData(data.experimentId!)
       }, 200)
     })
 


### PR DESCRIPTION
## Summary

- Add `fetchRewardComponentChartData` to metricsStore that builds AlignedData (steps, helpfulness, harmlessness, honesty) with union step axis and null-fill for missing values
- Wire `rewards:recorded` event handler to trigger reward component chart data re-fetch alongside existing `fetchLatestRewardSignals`
- Render `MultiLineChart` in ChartsArea Reward Components tab when data is available, placeholder when not
- 6 new tests covering aligned data, null-fill, empty state, live updates, and component rendering

## Test plan

- [x] `fetchRewardComponentChartData` populates aligned data for 3 components
- [x] Null-fills missing steps when components report at different intervals
- [x] Returns empty arrays when no reward signal data exists
- [x] `rewards:recorded` event triggers re-fetch with 200ms debounce
- [x] Reward Components tab renders MultiLineChart when data available
- [x] Reward Components tab shows placeholder when no data
- [x] All 319 existing tests continue to pass

## Files changed

| File | Change |
|------|--------|
| `frontend/src/stores/metricsStore.ts` | +state, +method, +event handler, +reset |
| `frontend/src/components/Experiments/ChartsArea.tsx` | +MultiLineChart import, +selectors, +useEffect, +render branch |
| `frontend/src/__tests__/stores/metricsStore.test.ts` | +4 tests |
| `frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx` | +2 tests |
| `docs/tdd/032-live-data-updates.md` | TDD document |

Generated with [Claude Code](https://claude.com/claude-code)