### PR TITLE
[codex] fix project test plan follow-ups

### DIFF
--- a/app_api_test.go
+++ b/app_api_test.go
@@ -666,6 +666,35 @@ func TestApp_CreateProject_WithSeed(t *testing.T) {
 	}
 }
 
+func TestApp_OpenProject_ReopensSeededProjectExperiments(t *testing.T) {
+	app := newTestApp(t)
+	dir := filepath.Join(t.TempDir(), "seeded")
+
+	if _, err := app.CreateProject("seeded", dir, "blank", true); err != nil {
+		t.Fatalf("CreateProject with seed failed: %v", err)
+	}
+	createdExperiments, err := app.ListExperiments()
+	if err != nil {
+		t.Fatalf("ListExperiments after create failed: %v", err)
+	}
+	if len(createdExperiments) == 0 {
+		t.Fatal("expected seeded experiments after create")
+	}
+
+	app.CloseProject()
+
+	if _, err := app.OpenProject(dir); err != nil {
+		t.Fatalf("OpenProject failed: %v", err)
+	}
+	reopenedExperiments, err := app.ListExperiments()
+	if err != nil {
+		t.Fatalf("ListExperiments after reopen failed: %v", err)
+	}
+	if len(reopenedExperiments) != len(createdExperiments) {
+		t.Fatalf("expected %d seeded experiments after reopen, got %d", len(createdExperiments), len(reopenedExperiments))
+	}
+}
+
 func TestApp_CreateProject_WithSeed_MultipleProjectsHaveMetricsAndAnnotations(t *testing.T) {
 	app := newTestApp(t)
 

--- a/frontend/src/__mocks__/wailsjs/go/main/App.ts
+++ b/frontend/src/__mocks__/wailsjs/go/main/App.ts
@@ -40,6 +40,19 @@ let mockRemoveRecentProjectError: Error | null = null
 let mockCreateProjectError: Error | null = null
 let mockOpenProjectError: Error | null = null
 let mockOpenFolderAsProjectError: Error | null = null
+let lastCreateProjectCall: {
+  name: string
+  dir: string
+  template: string
+  seedDemo: boolean
+} | null = null
+
+function addRecentProject(path: string, name: string): void {
+  mockRecentProjects = [
+    { path, name } as project.RecentProject,
+    ...mockRecentProjects.filter((r) => r.path !== path),
+  ]
+}
 
 // --- Existing methods ---
 
@@ -276,6 +289,12 @@ export function CreateProject(
   _seedDemo: boolean,
 ): Promise<project.Project> {
   if (mockCreateProjectError) return Promise.reject(mockCreateProjectError)
+  lastCreateProjectCall = {
+    name,
+    dir: _dir,
+    template: _template,
+    seedDemo: _seedDemo,
+  }
   const proj = new project.Project({
     id: crypto.randomUUID(),
     name,
@@ -284,7 +303,7 @@ export function CreateProject(
     updatedAt: Math.floor(Date.now() / 1000),
   } as Record<string, unknown>)
   mockCurrentProject = proj
-  mockRecentProjects.unshift({ path: _dir, name } as project.RecentProject)
+  addRecentProject(_dir, name)
   mockCurrentProjectStatus = new main.CurrentProjectStatus({
     project: proj,
     config: null,
@@ -305,6 +324,7 @@ export function OpenProject(dir: string): Promise<project.Project> {
     updatedAt: Math.floor(Date.now() / 1000),
   } as Record<string, unknown>)
   mockCurrentProject = proj
+  addRecentProject(dir, proj.name)
   mockCurrentProjectStatus = new main.CurrentProjectStatus({
     project: proj,
     config: null,
@@ -329,6 +349,7 @@ export function OpenFolderAsProject(
     updatedAt: Math.floor(Date.now() / 1000),
   } as Record<string, unknown>)
   mockCurrentProject = proj
+  addRecentProject(dir, name)
   mockCurrentProjectStatus = new main.CurrentProjectStatus({
     project: proj,
     config: null,
@@ -436,6 +457,7 @@ export function __resetMockState(): void {
   mockCreateProjectError = null
   mockOpenProjectError = null
   mockOpenFolderAsProjectError = null
+  lastCreateProjectCall = null
 }
 
 export function __setListExperimentsOverride(
@@ -477,6 +499,15 @@ export function __setRemoveRecentProjectError(error: Error | null): void {
 
 export function __setCreateProjectError(error: Error | null): void {
   mockCreateProjectError = error
+}
+
+export function __getLastCreateProjectCall(): {
+  name: string
+  dir: string
+  template: string
+  seedDemo: boolean
+} | null {
+  return lastCreateProjectCall ? { ...lastCreateProjectCall } : null
 }
 
 export function __setOpenProjectError(error: Error | null): void {

--- a/frontend/src/__mocks__/wailsjs/go/main/App.ts
+++ b/frontend/src/__mocks__/wailsjs/go/main/App.ts
@@ -36,6 +36,7 @@ let mockCurrentProjectStatus = new main.CurrentProjectStatus({
 let mockOpenFolderDialogResult: string = ''
 let mockOpenFolderDialogError: Error | null = null
 let mockIsFluxProjectResult: boolean = false
+let mockDefaultProjectsDirResult: string | Promise<string> = '/tmp/projects'
 let mockRemoveRecentProjectError: Error | null = null
 let mockCreateProjectError: Error | null = null
 let mockOpenProjectError: unknown = null
@@ -385,7 +386,7 @@ export function ListRecentProjects(): Promise<project.RecentProject[]> {
 }
 
 export function GetDefaultProjectsDir(): Promise<string> {
-  return Promise.resolve('/tmp/projects')
+  return Promise.resolve(mockDefaultProjectsDirResult)
 }
 
 export function OpenFolderDialog(): Promise<string> {
@@ -453,6 +454,7 @@ export function __resetMockState(): void {
   mockOpenFolderDialogResult = ''
   mockOpenFolderDialogError = null
   mockIsFluxProjectResult = false
+  mockDefaultProjectsDirResult = '/tmp/projects'
   mockRemoveRecentProjectError = null
   mockCreateProjectError = null
   mockOpenProjectError = null
@@ -491,6 +493,10 @@ export function __setOpenFolderDialogResult(result: string, error?: Error): void
 
 export function __setIsFluxProjectResult(result: boolean): void {
   mockIsFluxProjectResult = result
+}
+
+export function __setDefaultProjectsDirResult(result: string | Promise<string>): void {
+  mockDefaultProjectsDirResult = result
 }
 
 export function __setRemoveRecentProjectError(error: Error | null): void {

--- a/frontend/src/__mocks__/wailsjs/go/main/App.ts
+++ b/frontend/src/__mocks__/wailsjs/go/main/App.ts
@@ -38,8 +38,8 @@ let mockOpenFolderDialogError: Error | null = null
 let mockIsFluxProjectResult: boolean = false
 let mockRemoveRecentProjectError: Error | null = null
 let mockCreateProjectError: Error | null = null
-let mockOpenProjectError: Error | null = null
-let mockOpenFolderAsProjectError: Error | null = null
+let mockOpenProjectError: unknown = null
+let mockOpenFolderAsProjectError: unknown = null
 let lastCreateProjectCall: {
   name: string
   dir: string
@@ -510,11 +510,11 @@ export function __getLastCreateProjectCall(): {
   return lastCreateProjectCall ? { ...lastCreateProjectCall } : null
 }
 
-export function __setOpenProjectError(error: Error | null): void {
+export function __setOpenProjectError(error: unknown): void {
   mockOpenProjectError = error
 }
 
-export function __setOpenFolderAsProjectError(error: Error | null): void {
+export function __setOpenFolderAsProjectError(error: unknown): void {
   mockOpenFolderAsProjectError = error
 }
 

--- a/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/ChartsArea.test.tsx
@@ -1,12 +1,9 @@
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ChartsArea } from '@components/Experiments/ChartsArea'
 import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
-import {
-  __resetMockState,
-  RecordMetrics,
-  RecordRewardSignals,
-} from '../../../__mocks__/wailsjs/go/main/App'
-import { metrics } from '../../../__mocks__/wailsjs/go/models'
+import { useAnnotationStore, __resetAnnotationStore } from '@stores/annotationStore'
+import { __resetMockState } from '../../../__mocks__/wailsjs/go/main/App'
+import type { AlignedData } from 'uplot'
 
 // Mock uPlot (same pattern as TimeSeriesChart test)
 const mockSetData = jest.fn()
@@ -25,7 +22,24 @@ jest.mock('uplot/dist/uPlot.min.css', () => ({}))
 beforeEach(() => {
   __resetMockState()
   __resetMetricsStore()
+  __resetAnnotationStore()
+  useMetricsStore.setState({
+    fetchChartData: jest.fn(async () => {}),
+    fetchRewardComponentChartData: jest.fn(async () => {}),
+  })
+  useAnnotationStore.setState({
+    fetchAnnotations: jest.fn(async () => {}),
+    initialize: jest.fn(),
+  })
 })
+
+const OVERVIEW_CHART_DATA: AlignedData = [
+  [1, 2],
+  [2.5, 1.8],
+  [0.1, 0.5],
+]
+
+const REWARD_COMPONENT_CHART_DATA: AlignedData = [[10], [0.8], [0.7], [0.75]]
 
 describe('ChartsArea', () => {
   it('renders three chart tabs', () => {
@@ -56,101 +70,44 @@ describe('ChartsArea', () => {
     expect(screen.getByText('No metrics data yet')).toBeInTheDocument()
   })
 
-  it('renders chart when chart data is available', async () => {
-    await RecordMetrics('exp-1', [
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'loss',
-        value: 2.5,
-        timestamp: 1000,
-      }),
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 2,
-        name: 'loss',
-        value: 1.8,
-        timestamp: 2000,
-      }),
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'reward',
-        value: 0.1,
-        timestamp: 1000,
-      }),
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 2,
-        name: 'reward',
-        value: 0.5,
-        timestamp: 2000,
-      }),
-    ])
-
-    await act(async () => {
-      await useMetricsStore.getState().fetchChartData('exp-1')
-    })
+  it('renders chart when chart data is available', () => {
+    useMetricsStore.setState((state) => ({
+      chartData: {
+        ...state.chartData,
+        'exp-1': OVERVIEW_CHART_DATA,
+      },
+    }))
 
     render(<ChartsArea experimentId="exp-1" />)
     expect(screen.getByTestId('timeseries-chart')).toBeInTheDocument()
   })
 
-  it('shows placeholder on non-Overview tabs', async () => {
-    await RecordMetrics('exp-1', [
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'loss',
-        value: 2.5,
-        timestamp: 1000,
-      }),
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'reward',
-        value: 0.1,
-        timestamp: 1000,
-      }),
-    ])
-
-    await act(async () => {
-      await useMetricsStore.getState().fetchChartData('exp-1')
-    })
+  it('shows placeholder on non-Overview tabs', () => {
+    useMetricsStore.setState((state) => ({
+      chartData: {
+        ...state.chartData,
+        'exp-1': OVERVIEW_CHART_DATA,
+      },
+    }))
 
     render(<ChartsArea experimentId="exp-1" />)
     fireEvent.click(screen.getByText('Reward Components'))
     expect(screen.queryByTestId('timeseries-chart')).not.toBeInTheDocument()
   })
 
-  it('renders MultiLineChart in Reward Components tab when data available', async () => {
-    await RecordRewardSignals('exp-1', [
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'helpfulness',
-        value: 0.8,
-        distribution: '',
-      }),
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'harmlessness',
-        value: 0.7,
-        distribution: '',
-      }),
-      new metrics.RewardSignal({
-        experiment_id: 'exp-1',
-        step: 10,
-        component: 'honesty',
-        value: 0.75,
-        distribution: '',
-      }),
-    ])
-
-    await act(async () => {
-      await useMetricsStore.getState().fetchRewardComponentChartData('exp-1')
-    })
+  it('renders MultiLineChart in Reward Components tab when data available', () => {
+    useMetricsStore.setState((state) => ({
+      rewardComponentChartData: {
+        ...state.rewardComponentChartData,
+        'exp-1': REWARD_COMPONENT_CHART_DATA,
+      },
+    }))
+    useAnnotationStore.setState((state) => ({
+      annotations: {
+        ...state.annotations,
+        'exp-1': [],
+      },
+    }))
 
     render(<ChartsArea experimentId="exp-1" />)
     fireEvent.click(screen.getByText('Reward Components'))

--- a/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
+++ b/frontend/src/__tests__/components/Experiments/MetricsGrid.test.tsx
@@ -1,36 +1,33 @@
-import { render, screen, act } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MetricsGrid } from '@components/Experiments/MetricsGrid'
 import { useMetricsStore, __resetMetricsStore } from '@stores/metricsStore'
-import { __resetMockState, RecordMetrics } from '../../../__mocks__/wailsjs/go/main/App'
-import { metrics } from '../../../__mocks__/wailsjs/go/models'
+import { __resetMockState } from '../../../__mocks__/wailsjs/go/main/App'
 
 beforeEach(() => {
   __resetMockState()
   __resetMetricsStore()
+  useMetricsStore.setState({
+    fetchLatestMetrics: jest.fn(async () => {}),
+    fetchSparklineData: jest.fn(async () => {}),
+    fetchLatestRewardSignals: jest.fn(async () => {}),
+  })
 })
 
 describe('MetricsGrid', () => {
-  it('renders four metric cards', async () => {
-    await RecordMetrics('exp-1', [
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'kl',
-        value: 0.045,
-        timestamp: 1000,
-      }),
-      new metrics.Metric({
-        experiment_id: 'exp-1',
-        step: 1,
-        name: 'learning_rate',
-        value: 0.0003,
-        timestamp: 1000,
-      }),
-    ])
-
-    await act(async () => {
-      await useMetricsStore.getState().fetchLatestMetrics('exp-1')
-      await useMetricsStore.getState().fetchSparklineData('exp-1')
+  it('renders four metric cards', () => {
+    useMetricsStore.setState({
+      latestMetrics: {
+        'exp-1': {
+          kl: 0.045,
+          learning_rate: 0.0003,
+        },
+      },
+      sparklineData: {
+        'exp-1': {
+          kl: [{ step: 1, value: 0.045 }],
+          learning_rate: [{ step: 1, value: 0.0003 }],
+        },
+      },
     })
 
     render(<MetricsGrid experimentId="exp-1" />)

--- a/frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx
+++ b/frontend/src/__tests__/components/layout/panels/MainPanel.test.tsx
@@ -9,11 +9,17 @@ jest.mock('../../../../../wailsjs/runtime/runtime', () => ({
   EventsOn: jest.fn(),
 }))
 
-jest.mock('../../../../../wailsjs/go/main/App', () => ({
-  ListExperiments: jest.fn().mockResolvedValue([]),
-  GetLatestMetrics: jest.fn().mockResolvedValue([]),
-  QueryMetrics: jest.fn().mockResolvedValue([]),
-  QueryRewardSignals: jest.fn().mockResolvedValue([]),
+jest.mock('@components/Experiments/MetricsGrid', () => ({
+  MetricsGrid: () => <div data-testid="metrics-grid">Mock Metrics Grid</div>,
+}))
+
+jest.mock('@components/Experiments/ChartsArea', () => ({
+  ChartsArea: () => (
+    <div>
+      <div>Overview</div>
+      <div>No metrics data yet</div>
+    </div>
+  ),
 }))
 
 function makeExperiment(overrides: Partial<Record<string, unknown>> = {}): experiment.Experiment {
@@ -35,6 +41,13 @@ beforeEach(() => {
     selectedId: null,
     loading: false,
     error: null,
+  })
+  useMetricsStore.setState({
+    latestMetrics: {},
+    sparklineData: {},
+    latestRewardSignals: {},
+    chartData: {},
+    rewardComponentChartData: {},
   })
 })
 

--- a/frontend/src/__tests__/components/project/AppShellViewMode.test.tsx
+++ b/frontend/src/__tests__/components/project/AppShellViewMode.test.tsx
@@ -115,7 +115,7 @@ describe('AppShell view mode', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     __setOpenFolderDialogResult('/tmp/raw-data')
     __setIsFluxProjectResult(false)
-    __setOpenFolderAsProjectError(new Error('Folder is read-only'))
+    __setOpenFolderAsProjectError('Folder is read-only')
 
     render(<AppShell />)
 

--- a/frontend/src/__tests__/components/project/AppShellViewMode.test.tsx
+++ b/frontend/src/__tests__/components/project/AppShellViewMode.test.tsx
@@ -1,14 +1,32 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { AppShell } from '@components/layout'
-import { __resetMockState, __setCurrentProjectStatus } from '../../../__mocks__/wailsjs/go/main/App'
+import {
+  __resetMockState,
+  __setCurrentProjectStatus,
+  __setOpenFolderDialogResult,
+  __setIsFluxProjectResult,
+  __setOpenFolderAsProjectError,
+} from '../../../__mocks__/wailsjs/go/main/App'
 import { __resetListeners } from '../../../__mocks__/wailsjs/runtime/runtime'
 import { useProjectStore, __resetProjectStoreInitialized } from '@stores/projectStore'
+import {
+  useExperimentStore,
+  __resetInitialized as __resetExperimentStoreInitialized,
+} from '@stores/experimentStore'
 import { project } from '../../../__mocks__/wailsjs/go/models'
 
 beforeEach(() => {
   __resetMockState()
   __resetListeners()
   __resetProjectStoreInitialized()
+  __resetExperimentStoreInitialized()
+  useExperimentStore.setState({
+    experiments: [],
+    selectedId: null,
+    loading: false,
+    error: null,
+  })
 })
 
 describe('AppShell view mode', () => {
@@ -72,5 +90,88 @@ describe('AppShell view mode', () => {
       // Store is loaded (loading becomes false)
       expect(useProjectStore.getState().loading).toBe(false)
     })
+  })
+
+  it('shows a visible error when Open Existing selects a non-Flux directory', async () => {
+    const user = userEvent.setup()
+    __setOpenFolderDialogResult('/tmp/not-a-project')
+    __setIsFluxProjectResult(false)
+
+    render(<AppShell />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('welcome-screen')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /open existing project/i }))
+
+    expect(
+      screen.getByText(/no flux\.yaml found in this directory\. use "open folder" to import/i)
+    ).toBeInTheDocument()
+  })
+
+  it('shows inline import errors instead of silently swallowing them', async () => {
+    const user = userEvent.setup()
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    __setOpenFolderDialogResult('/tmp/raw-data')
+    __setIsFluxProjectResult(false)
+    __setOpenFolderAsProjectError(new Error('Folder is read-only'))
+
+    render(<AppShell />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('welcome-screen')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /open folder/i }))
+    await user.click(screen.getByRole('button', { name: /create & open/i }))
+
+    expect(await screen.findByText(/folder is read-only/i)).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /import folder/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create & open/i })).not.toBeDisabled()
+    errorSpy.mockRestore()
+  })
+
+  it('does not fire open-existing shortcut while typing in a text field', async () => {
+    __setOpenFolderDialogResult('/tmp/not-a-project')
+    __setIsFluxProjectResult(false)
+
+    render(<AppShell />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('welcome-screen')).toBeInTheDocument()
+    })
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+
+    fireEvent.keyDown(input, { key: 'O', metaKey: true, shiftKey: true })
+
+    expect(
+      screen.queryByText(/no flux\.yaml found in this directory\. use "open folder" to import/i)
+    ).not.toBeInTheDocument()
+
+    input.remove()
+  })
+
+  it('does not open a second modal from project shortcuts while a modal is already open', async () => {
+    const user = userEvent.setup()
+    __setOpenFolderDialogResult('/tmp/raw-data')
+    __setIsFluxProjectResult(false)
+
+    render(<AppShell />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('welcome-screen')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /new project/i }))
+    expect(screen.getByRole('dialog', { name: /new project/i })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'o', metaKey: true })
+
+    expect(screen.queryByRole('dialog', { name: /import folder/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: /new project/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/components/project/ImportDialog.test.tsx
+++ b/frontend/src/__tests__/components/project/ImportDialog.test.tsx
@@ -24,9 +24,9 @@ describe('ImportDialog', () => {
     expect(screen.getByLabelText(/project name/i)).toHaveValue('ml-project')
   })
 
-  it('shows starter experiments toggle defaulting to off', () => {
+  it('shows demo experiments toggle defaulting to off', () => {
     render(<ImportDialog {...defaultProps} />)
-    const toggle = screen.getByLabelText(/include starter experiments/i)
+    const toggle = screen.getByLabelText(/add demo experiments to flux/i)
     expect(toggle).not.toBeChecked()
   })
 
@@ -52,5 +52,17 @@ describe('ImportDialog', () => {
     render(<ImportDialog {...defaultProps} />)
     await user.click(screen.getByRole('button', { name: /cancel/i }))
     expect(defaultProps.onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows inline error text when provided', () => {
+    render(<ImportDialog {...defaultProps} error="Folder is read-only" />)
+    expect(screen.getByText(/folder is read-only/i)).toBeInTheDocument()
+  })
+
+  it('shows loading state while submitting', () => {
+    render(<ImportDialog {...defaultProps} submitting={true} />)
+    expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+    expect(screen.getByLabelText(/project name/i)).toBeDisabled()
   })
 })

--- a/frontend/src/__tests__/components/project/NewProjectWizard.test.tsx
+++ b/frontend/src/__tests__/components/project/NewProjectWizard.test.tsx
@@ -4,6 +4,7 @@ import { NewProjectWizard } from '@components/project'
 import {
   __resetMockState,
   __getLastCreateProjectCall,
+  __setDefaultProjectsDirResult,
   __setCreateProjectError,
   __setOpenFolderDialogResult,
 } from '../../../__mocks__/wailsjs/go/main/App'
@@ -28,6 +29,14 @@ async function renderWizard() {
 
 function expectProjectPath(path: string) {
   expect(screen.getAllByText(path).length).toBeGreaterThan(0)
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
 }
 
 describe('NewProjectWizard', () => {
@@ -145,6 +154,28 @@ describe('NewProjectWizard', () => {
       await user.type(nameInput, 'changed-name')
       expect(projectsFolderInput).toHaveValue('/custom/projects')
       expectProjectPath('/custom/projects/changed-name')
+    })
+
+    it('preserves a typed projects folder when the default folder loads later', async () => {
+      const user = userEvent.setup()
+      const defaultDir = deferred<string>()
+      __setDefaultProjectsDirResult(defaultDir.promise)
+
+      render(<NewProjectWizard {...defaultProps} />)
+      await user.click(screen.getByRole('button', { name: /reward model/i }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      const projectsFolderInput = screen.getByLabelText(/projects folder/i)
+      await user.type(projectsFolderInput, '/custom/projects')
+      expectProjectPath('/custom/projects/reward-model-v1')
+
+      await act(async () => {
+        defaultDir.resolve('/tmp/projects')
+        await defaultDir.promise
+      })
+
+      expect(projectsFolderInput).toHaveValue('/custom/projects')
+      expectProjectPath('/custom/projects/reward-model-v1')
     })
 
     it('shows add demo experiments toggle', async () => {

--- a/frontend/src/__tests__/components/project/NewProjectWizard.test.tsx
+++ b/frontend/src/__tests__/components/project/NewProjectWizard.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NewProjectWizard } from '@components/project'
 import {
   __resetMockState,
+  __getLastCreateProjectCall,
   __setCreateProjectError,
   __setOpenFolderDialogResult,
 } from '../../../__mocks__/wailsjs/go/main/App'
@@ -18,15 +19,26 @@ beforeEach(() => {
   __setCreateProjectError(null)
 })
 
+async function renderWizard() {
+  await act(async () => {
+    render(<NewProjectWizard {...defaultProps} />)
+    await Promise.resolve()
+  })
+}
+
+function expectProjectPath(path: string) {
+  expect(screen.getAllByText(path).length).toBeGreaterThan(0)
+}
+
 describe('NewProjectWizard', () => {
   describe('Modal shell', () => {
-    it('renders as a modal dialog', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('renders as a modal dialog', async () => {
+      await renderWizard()
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    it('renders step indicator with 3 steps', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('renders step indicator with 3 steps', async () => {
+      await renderWizard()
       expect(screen.getByText('Template')).toBeInTheDocument()
       expect(screen.getByText('Details')).toBeInTheDocument()
       expect(screen.getByText('Review')).toBeInTheDocument()
@@ -34,52 +46,59 @@ describe('NewProjectWizard', () => {
 
     it('calls onClose when backdrop is clicked', async () => {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.click(screen.getByTestId('wizard-backdrop'))
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
     })
 
     it('calls onClose when Escape is pressed', async () => {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.keyboard('{Escape}')
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onClose when Cancel is clicked', async () => {
+      const user = userEvent.setup()
+      await renderWizard()
+      await user.click(screen.getByRole('button', { name: /cancel/i }))
       expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('Step 1: Template', () => {
-    it('renders template heading', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('renders template heading', async () => {
+      await renderWizard()
       expect(screen.getByText('What kind of project?')).toBeInTheDocument()
     })
 
-    it('renders selectable template cards', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('renders selectable template cards', async () => {
+      await renderWizard()
       expect(screen.getByRole('button', { name: /reward model/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /blank/i })).toBeInTheDocument()
     })
 
-    it('renders coming-soon templates as disabled', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('renders coming-soon templates as disabled', async () => {
+      await renderWizard()
       expect(screen.getByText(/classification/i)).toBeInTheDocument()
       expect(screen.getByText(/fine-tuning/i)).toBeInTheDocument()
     })
 
-    it('Continue button is disabled until a template is selected', () => {
-      render(<NewProjectWizard {...defaultProps} />)
+    it('Continue button is disabled until a template is selected', async () => {
+      await renderWizard()
       expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
     })
 
     it('enables Continue after selecting a template', async () => {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.click(screen.getByRole('button', { name: /reward model/i }))
       expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled()
     })
 
     it('advances to step 2 when Continue is clicked', async () => {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.click(screen.getByRole('button', { name: /reward model/i }))
       await user.click(screen.getByRole('button', { name: /continue/i }))
       expect(screen.getByLabelText(/project name/i)).toBeInTheDocument()
@@ -89,7 +108,7 @@ describe('NewProjectWizard', () => {
   describe('Step 2: Details', () => {
     async function advanceToStep2() {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.click(screen.getByRole('button', { name: /reward model/i }))
       await user.click(screen.getByRole('button', { name: /continue/i }))
       return user
@@ -101,10 +120,11 @@ describe('NewProjectWizard', () => {
       expect(nameInput).toHaveValue('reward-model-v1')
     })
 
-    it('shows location field with auto-generated path', async () => {
+    it('shows projects folder with auto-generated project path', async () => {
       await advanceToStep2()
-      const locationInput = screen.getByLabelText(/location/i)
-      expect((locationInput as HTMLInputElement).value).toContain('reward-model-v1')
+      const projectsFolderInput = screen.getByLabelText(/projects folder/i)
+      expect(projectsFolderInput).toHaveValue('/tmp/projects')
+      expectProjectPath('/tmp/projects/reward-model-v1')
     })
 
     it('auto-updates location when name changes (before manual edit)', async () => {
@@ -112,24 +132,27 @@ describe('NewProjectWizard', () => {
       const nameInput = screen.getByLabelText(/project name/i)
       await user.clear(nameInput)
       await user.type(nameInput, 'my-custom-name')
-      const locationInput = screen.getByLabelText(/location/i)
-      expect((locationInput as HTMLInputElement).value).toContain('my-custom-name')
+      expectProjectPath('/tmp/projects/my-custom-name')
     })
 
-    it('stops auto-sync after manual location edit', async () => {
+    it('uses the projects folder as the base path', async () => {
       const user = await advanceToStep2()
-      const locationInput = screen.getByLabelText(/location/i)
-      await user.clear(locationInput)
-      await user.type(locationInput, '/custom/path')
+      const projectsFolderInput = screen.getByLabelText(/projects folder/i)
+      await user.clear(projectsFolderInput)
+      await user.type(projectsFolderInput, '/custom/projects')
       const nameInput = screen.getByLabelText(/project name/i)
       await user.clear(nameInput)
       await user.type(nameInput, 'changed-name')
-      expect(locationInput).toHaveValue('/custom/path')
+      expect(projectsFolderInput).toHaveValue('/custom/projects')
+      expectProjectPath('/custom/projects/changed-name')
     })
 
-    it('shows include starter experiments toggle', async () => {
+    it('shows add demo experiments toggle', async () => {
       await advanceToStep2()
-      expect(screen.getByLabelText(/include starter experiments/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/add demo experiments to flux/i)).toBeInTheDocument()
+      expect(
+        screen.getByText(/seeds flux's local database with sample runs for this project/i)
+      ).toBeInTheDocument()
     })
 
     it('appends the generated project directory after browsing for a parent folder', async () => {
@@ -138,20 +161,30 @@ describe('NewProjectWizard', () => {
 
       await user.click(screen.getByRole('button', { name: /browse/i }))
 
-      const locationInput = screen.getByLabelText(/location/i)
-      expect(locationInput).toHaveValue('/custom/projects/reward-model-v1')
+      const projectsFolderInput = screen.getByLabelText(/projects folder/i)
+      expect(projectsFolderInput).toHaveValue('/custom/projects')
+      expectProjectPath('/custom/projects/reward-model-v1')
 
       const nameInput = screen.getByLabelText(/project name/i)
       await user.clear(nameInput)
       await user.type(nameInput, 'Renamed Project')
 
-      expect(locationInput).toHaveValue('/custom/projects/renamed-project')
+      expectProjectPath('/custom/projects/renamed-project')
     })
 
     it('has Back button that returns to step 1', async () => {
       const user = await advanceToStep2()
       await user.click(screen.getByRole('button', { name: /back/i }))
       expect(screen.getByText('What kind of project?')).toBeInTheDocument()
+    })
+
+    it('defaults blank projects to no demo experiments', async () => {
+      const user = userEvent.setup()
+      await renderWizard()
+      await user.click(screen.getByRole('button', { name: /blank empty project/i }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      expect(screen.getByLabelText(/add demo experiments to flux/i)).not.toBeChecked()
     })
 
     it('disables Continue when name is empty', async () => {
@@ -165,7 +198,7 @@ describe('NewProjectWizard', () => {
   describe('Step 3: Review & Create', () => {
     async function advanceToStep3() {
       const user = userEvent.setup()
-      render(<NewProjectWizard {...defaultProps} />)
+      await renderWizard()
       await user.click(screen.getByRole('button', { name: /reward model/i }))
       await user.click(screen.getByRole('button', { name: /continue/i }))
       await user.click(screen.getByRole('button', { name: /continue/i }))
@@ -181,6 +214,21 @@ describe('NewProjectWizard', () => {
     it('calls CreateProject on create and closes on success', async () => {
       const user = await advanceToStep3()
       await user.click(screen.getByRole('button', { name: /create project/i }))
+      expect(defaultProps.onCreated).toHaveBeenCalledTimes(1)
+    })
+
+    it('creates blank projects without demo experiments by default', async () => {
+      const user = userEvent.setup()
+      await renderWizard()
+      await user.click(screen.getByRole('button', { name: /blank empty project/i }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+      await user.click(screen.getByRole('button', { name: /create project/i }))
+
+      expect(__getLastCreateProjectCall()).toMatchObject({
+        template: 'blank',
+        seedDemo: false,
+      })
       expect(defaultProps.onCreated).toHaveBeenCalledTimes(1)
     })
 

--- a/frontend/src/__tests__/components/project/ProjectSwitcher.test.tsx
+++ b/frontend/src/__tests__/components/project/ProjectSwitcher.test.tsx
@@ -95,4 +95,14 @@ describe('ProjectSwitcher', () => {
     await user.click(screen.getByText('other-proj'))
     expect(defaultProps.onSwitchProject).toHaveBeenCalledWith('/tmp/other-proj')
   })
+
+  it('includes recent projects in keyboard menu navigation', async () => {
+    const user = userEvent.setup()
+    render(<ProjectSwitcher {...defaultProps} />)
+
+    await user.click(screen.getByRole('button', { name: /project menu/i }))
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}')
+
+    expect(screen.getByRole('menuitem', { name: /other-proj/i })).toHaveFocus()
+  })
 })

--- a/frontend/src/__tests__/components/project/WelcomeScreen.test.tsx
+++ b/frontend/src/__tests__/components/project/WelcomeScreen.test.tsx
@@ -17,10 +17,10 @@ beforeEach(() => {
 })
 
 describe('WelcomeScreen', () => {
-  it('renders the Flux branding and tagline', () => {
+  it('renders the Flux branding prominently', () => {
     render(<WelcomeScreen {...defaultProps} />)
-    expect(screen.getByText('Flux')).toBeInTheDocument()
-    expect(screen.getByText('The ML development environment')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /flux/i })).toBeInTheDocument()
+    expect(screen.getByText('Write code. Watch it learn.')).toBeInTheDocument()
   })
 
   it('renders all action buttons', () => {

--- a/frontend/src/__tests__/components/project/wizardReducer.test.ts
+++ b/frontend/src/__tests__/components/project/wizardReducer.test.ts
@@ -40,4 +40,25 @@ describe('wizardReducer', () => {
     state = wizardReducer(state, { type: 'SET_DEFAULT_DIR', dir: '/tmp/projects' })
     expect(state.location).toBe('/custom/location')
   })
+
+  it('preserves a user-selected projects folder when the async default dir loads later', () => {
+    let state = createInitialState()
+
+    state = wizardReducer(state, { type: 'SET_TEMPLATE', template: 'reward-model' })
+    state = wizardReducer(state, {
+      type: 'SET_PROJECTS_DIR',
+      dir: '/custom/projects',
+      manual: true,
+    })
+
+    expect(state.defaultProjectsDir).toBe('/custom/projects')
+    expect(state.location).toBe('/custom/projects/reward-model-v1')
+
+    state = wizardReducer(state, { type: 'SET_DEFAULT_DIR', dir: '/tmp/projects' })
+    expect(state.defaultProjectsDir).toBe('/custom/projects')
+    expect(state.location).toBe('/custom/projects/reward-model-v1')
+
+    state = wizardReducer(state, { type: 'SET_PROJECT_NAME', name: 'renamed-project' })
+    expect(state.location).toBe('/custom/projects/renamed-project')
+  })
 })

--- a/frontend/src/__tests__/components/project/wizardReducer.test.ts
+++ b/frontend/src/__tests__/components/project/wizardReducer.test.ts
@@ -1,6 +1,22 @@
 import { createInitialState, wizardReducer } from '../../../components/project/wizardReducer'
 
 describe('wizardReducer', () => {
+  it('defaults blank projects to no demo experiments', () => {
+    let state = createInitialState()
+
+    state = wizardReducer(state, { type: 'SET_TEMPLATE', template: 'blank' })
+
+    expect(state.seedDemo).toBe(false)
+  })
+
+  it('defaults reward-model projects to demo experiments enabled', () => {
+    let state = createInitialState()
+
+    state = wizardReducer(state, { type: 'SET_TEMPLATE', template: 'reward-model' })
+
+    expect(state.seedDemo).toBe(true)
+  })
+
   it('recomputes the generated location when the default projects dir loads later', () => {
     let state = createInitialState()
 

--- a/frontend/src/__tests__/navigation.test.tsx
+++ b/frontend/src/__tests__/navigation.test.tsx
@@ -3,6 +3,10 @@ import App from '../components/App'
 import { __resetMockState, __setCurrentProjectStatus } from '../__mocks__/wailsjs/go/main/App'
 import { __resetListeners } from '../__mocks__/wailsjs/runtime/runtime'
 import { __resetProjectStoreInitialized } from '@stores/projectStore'
+import {
+  useExperimentStore,
+  __resetInitialized as __resetExperimentStoreInitialized,
+} from '@stores/experimentStore'
 import { project } from '../__mocks__/wailsjs/go/models'
 
 function makeProject() {
@@ -19,6 +23,13 @@ beforeEach(() => {
   __resetMockState()
   __resetListeners()
   __resetProjectStoreInitialized()
+  __resetExperimentStoreInitialized()
+  useExperimentStore.setState({
+    experiments: [],
+    selectedId: null,
+    loading: false,
+    error: null,
+  })
   // Set a project so AppShell shows the project view (not welcome)
   __setCurrentProjectStatus({ project: makeProject() })
 })
@@ -116,6 +127,21 @@ describe('Navigation', () => {
       await renderAndWait()
       fireEvent.keyDown(document, { key: '2', ctrlKey: true })
       expect(screen.getByTestId('compare-view')).toBeInTheDocument()
+    })
+
+    it('does not switch views while typing in a form field', async () => {
+      await renderAndWait()
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      fireEvent.keyDown(input, { key: '2', metaKey: true })
+
+      expect(screen.getByTestId('experiments-view')).toBeInTheDocument()
+      expect(screen.queryByTestId('compare-view')).not.toBeInTheDocument()
+
+      input.remove()
     })
   })
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   OpenFolderAsProject,
 } from '../../../wailsjs/go/main/App'
 import { useKeyboardShortcuts, useLayoutPersistence } from '../../hooks'
+import { useExperimentStore } from '../../stores/experimentStore'
 import { useProjectStore } from '../../stores/projectStore'
 import {
   ProjectSwitcher,
@@ -28,6 +29,25 @@ const ALL_VIEWS = new Set<ViewId>(['experiments', 'compare', 'data', 'code'])
 const NO_PROJECT_COMPAT_DISABLED = new Set<ViewId>(['compare', 'data', 'code'])
 const EMPTY_DISABLED = new Set<ViewId>()
 
+function getErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback
+}
+
+function clearPaths(
+  errors: Record<string, string>,
+  paths: Array<string | undefined>
+): Record<string, string> {
+  const next = { ...errors }
+  let changed = false
+  for (const path of paths) {
+    if (path && next[path]) {
+      delete next[path]
+      changed = true
+    }
+  }
+  return changed ? next : errors
+}
+
 export function AppShell() {
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null)
   const [activeView, setActiveView] = useState<ViewId>('experiments')
@@ -38,17 +58,23 @@ export function AppShell() {
   const hydrated = useProjectStore((s) => s.hydrated)
   const initialize = useProjectStore((s) => s.initialize)
   const recentProjects = useProjectStore((s) => s.recentProjects)
+  const fetchStatus = useProjectStore((s) => s.fetchStatus)
   const fetchRecentProjects = useProjectStore((s) => s.fetchRecentProjects)
   const degraded = useProjectStore((s) => s.degraded)
   const closeProject = useProjectStore((s) => s.closeProject)
+  const fetchExperiments = useExperimentStore((s) => s.fetchExperiments)
 
   const [recentProjectErrors, setRecentProjectErrors] = useState<Record<string, string>>({})
   const [showWizard, setShowWizard] = useState(false)
   const [importState, setImportState] = useState<{ path: string; name: string } | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importSubmitting, setImportSubmitting] = useState(false)
+  const [shellError, setShellError] = useState<string | null>(null)
 
   // TODO: These will be driven by actual experiment state
   const [runningCount] = useState(0)
   const [alertCount] = useState(0)
+  const hasOpenModal = showWizard || importState !== null
 
   useEffect(() => {
     void initialize()
@@ -74,82 +100,118 @@ export function AppShell() {
     // TODO: Open command palette modal
   }, [])
 
+  const refreshWorkspaceData = useCallback(async () => {
+    await Promise.all([fetchStatus(), fetchRecentProjects(), fetchExperiments()])
+  }, [fetchStatus, fetchRecentProjects, fetchExperiments])
+
   const handleNewProject = useCallback(() => {
+    if (hasOpenModal) return
+    setShellError(null)
     setShowWizard(true)
-  }, [])
+  }, [hasOpenModal])
 
   const handleWizardClose = useCallback(() => {
     setShowWizard(false)
   }, [])
 
   const handleWizardCreated = useCallback(() => {
+    setShellError(null)
     setShowWizard(false)
-  }, [])
+    void refreshWorkspaceData()
+  }, [refreshWorkspaceData])
 
   const handleOpenFolder = useCallback(async () => {
+    if (hasOpenModal) return
+    setShellError(null)
     try {
       const dir = await OpenFolderDialog()
       if (!dir) return
+
       const isFlux = await IsFluxProject(dir)
       if (isFlux) {
-        await OpenProject(dir)
+        const proj = await OpenProject(dir)
+        setShellError(null)
+        setRecentProjectErrors((prev) => clearPaths(prev, [dir, proj.path]))
+        await refreshWorkspaceData()
       } else {
         const basename = dir.replace(/\\/g, '/').split('/').filter(Boolean).pop() || 'project'
+        setImportError(null)
+        setImportSubmitting(false)
         setImportState({ path: dir, name: basename })
       }
     } catch (err) {
+      setShellError(getErrorMessage(err, 'Failed to open folder.'))
       console.error('Open folder failed:', err)
     }
-  }, [])
+  }, [hasOpenModal, refreshWorkspaceData])
 
   const handleOpenExisting = useCallback(async () => {
+    if (hasOpenModal) return
+    setShellError(null)
     try {
       const dir = await OpenFolderDialog()
       if (!dir) return
+
       const isFlux = await IsFluxProject(dir)
       if (isFlux) {
-        await OpenProject(dir)
+        const proj = await OpenProject(dir)
+        setShellError(null)
+        setRecentProjectErrors((prev) => clearPaths(prev, [dir, proj.path]))
+        await refreshWorkspaceData()
       } else {
-        // TODO: Surface as toast when toast system is available
-        console.warn(`No flux.yaml found in ${dir}. Use "Open Folder" to import.`)
+        setShellError(
+          'No flux.yaml found in this directory. Use "Open Folder" to import a directory as a new project.'
+        )
       }
     } catch (err) {
+      setShellError(getErrorMessage(err, 'Failed to open existing project.'))
       console.error('Open existing failed:', err)
     }
-  }, [])
+  }, [hasOpenModal, refreshWorkspaceData])
 
   const handleImportConfirm = useCallback(
     async (name: string, seedDemo: boolean) => {
-      if (!importState) return
+      if (!importState || importSubmitting) return
+      setImportSubmitting(true)
+      setImportError(null)
       try {
-        await OpenFolderAsProject(importState.path, name, seedDemo)
+        const proj = await OpenFolderAsProject(importState.path, name, seedDemo)
+        setShellError(null)
+        setRecentProjectErrors((prev) => clearPaths(prev, [importState.path, proj.path]))
+        await refreshWorkspaceData()
+        setImportSubmitting(false)
+        setImportError(null)
         setImportState(null)
       } catch (err) {
+        setImportSubmitting(false)
+        setImportError(getErrorMessage(err, 'Failed to import folder.'))
         console.error('Import failed:', err)
       }
     },
-    [importState]
+    [importState, importSubmitting, refreshWorkspaceData]
   )
 
   const handleImportCancel = useCallback(() => {
+    if (importSubmitting) return
+    setImportError(null)
     setImportState(null)
-  }, [])
+  }, [importSubmitting])
 
-  const handleOpenRecentProject = useCallback(async (path: string) => {
-    try {
-      await OpenProject(path)
-      setRecentProjectErrors((prev) => {
-        const next = { ...prev }
-        delete next[path]
-        return next
-      })
-    } catch (err) {
-      setRecentProjectErrors((prev) => ({
-        ...prev,
-        [path]: err instanceof Error ? err.message : String(err),
-      }))
-    }
-  }, [])
+  const handleOpenRecentProject = useCallback(
+    async (path: string) => {
+      try {
+        const proj = await OpenProject(path)
+        setRecentProjectErrors((prev) => clearPaths(prev, [path, proj.path]))
+        await refreshWorkspaceData()
+      } catch (err) {
+        setRecentProjectErrors((prev) => ({
+          ...prev,
+          [path]: err instanceof Error ? err.message : String(err),
+        }))
+      }
+    },
+    [refreshWorkspaceData]
+  )
 
   const handleRemoveRecentProject = useCallback(
     async (path: string) => {
@@ -202,6 +264,7 @@ export function AppShell() {
     onNewProject: handleNewProject,
     onOpenFolder: handleOpenFolder,
     onOpenExisting: handleOpenExisting,
+    projectActionsDisabled: hasOpenModal,
   })
 
   // Bootstrap gate: show nothing until hydration is complete
@@ -255,6 +318,19 @@ export function AppShell() {
           onRemoveRecentProject={handleRemoveRecentProject}
         />
       </div>
+      {shellError && (
+        <div className="app-shell__notice app-shell__notice--error" role="alert">
+          <span className="app-shell__notice-message">{shellError}</span>
+          <button
+            type="button"
+            className="app-shell__notice-dismiss"
+            onClick={() => setShellError(null)}
+            aria-label="Dismiss message"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       {showWizard && (
         <NewProjectWizard onClose={handleWizardClose} onCreated={handleWizardCreated} />
       )}
@@ -264,6 +340,8 @@ export function AppShell() {
           folderName={importState.name}
           onConfirm={handleImportConfirm}
           onCancel={handleImportCancel}
+          error={importError}
+          submitting={importSubmitting}
         />
       )}
     </>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -30,7 +30,9 @@ const NO_PROJECT_COMPAT_DISABLED = new Set<ViewId>(['compare', 'data', 'code'])
 const EMPTY_DISABLED = new Set<ViewId>()
 
 function getErrorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error ? err.message : fallback
+  if (err instanceof Error) return err.message
+  if (err == null) return fallback
+  return String(err)
 }
 
 function clearPaths(

--- a/frontend/src/components/project/ImportDialog.css
+++ b/frontend/src/components/project/ImportDialog.css
@@ -60,6 +60,15 @@
   cursor: pointer;
 }
 
+.import-dialog__error {
+  font-size: var(--font-size-sm);
+  color: var(--color-error);
+  background: var(--color-error-dim);
+  border: 1px solid var(--color-error);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
 .import-dialog__actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/components/project/ImportDialog.tsx
+++ b/frontend/src/components/project/ImportDialog.tsx
@@ -6,15 +6,29 @@ interface ImportDialogProps {
   folderName: string
   onConfirm: (name: string, seedDemo: boolean) => void
   onCancel: () => void
+  error?: string | null
+  submitting?: boolean
 }
 
-export function ImportDialog({ folderPath, folderName, onConfirm, onCancel }: ImportDialogProps) {
+export function ImportDialog({
+  folderPath,
+  folderName,
+  onConfirm,
+  onCancel,
+  error = null,
+  submitting = false,
+}: ImportDialogProps) {
   const [name, setName] = useState(folderName)
   const [seedDemo, setSeedDemo] = useState(false)
 
   return (
     <div className="import-overlay">
-      <div className="import-overlay__backdrop" onClick={onCancel} />
+      <div
+        className="import-overlay__backdrop"
+        onClick={() => {
+          if (!submitting) onCancel()
+        }}
+      />
       <div className="import-dialog" role="dialog" aria-modal="true" aria-label="Import folder">
         <p className="import-dialog__message">
           <code>{folderPath}</code> doesn't have a <code>flux.yaml</code>. Flux will create one.
@@ -31,6 +45,7 @@ export function ImportDialog({ folderPath, folderName, onConfirm, onCancel }: Im
             value={name}
             onChange={(e) => setName(e.target.value)}
             autoFocus
+            disabled={submitting}
           />
         </div>
 
@@ -39,21 +54,32 @@ export function ImportDialog({ folderPath, folderName, onConfirm, onCancel }: Im
             type="checkbox"
             checked={seedDemo}
             onChange={(e) => setSeedDemo(e.target.checked)}
-            aria-label="Include starter experiments"
+            aria-label="Add demo experiments to Flux"
+            disabled={submitting}
           />
-          <span>Include starter experiments</span>
+          <span>Add demo experiments to Flux</span>
         </label>
 
+        {error && (
+          <div className="import-dialog__error" role="alert">
+            {error}
+          </div>
+        )}
+
         <div className="import-dialog__actions">
-          <button className="button button--secondary button--md" onClick={onCancel}>
+          <button
+            className="button button--secondary button--md"
+            onClick={onCancel}
+            disabled={submitting}
+          >
             Cancel
           </button>
           <button
             className="button button--primary button--md"
-            onClick={() => onConfirm(name, seedDemo)}
-            disabled={!name.trim()}
+            onClick={() => onConfirm(name.trim(), seedDemo)}
+            disabled={!name.trim() || submitting}
           >
-            Create &amp; Open
+            {submitting ? 'Creating...' : 'Create & Open'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/project/NewProjectWizard.css
+++ b/frontend/src/components/project/NewProjectWizard.css
@@ -272,6 +272,17 @@
   flex: 1;
 }
 
+.wizard-field__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.wizard-field__hint code {
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+}
+
 .wizard-toggle {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/project/NewProjectWizard.tsx
+++ b/frontend/src/components/project/NewProjectWizard.tsx
@@ -45,6 +45,10 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
     if (!state.creating) onClose()
   }, [onClose, state.creating])
 
+  const handleCancel = useCallback(() => {
+    if (!state.creating) onClose()
+  }, [onClose, state.creating])
+
   const handleContinue = useCallback(() => {
     if (state.step < 3) {
       dispatch({ type: 'GO_TO_STEP', step: (state.step + 1) as 1 | 2 | 3 })
@@ -58,7 +62,7 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
   }, [state.step])
 
   const handleCreate = useCallback(async () => {
-    if (!state.template) return
+    if (!state.template || !state.location.trim()) return
     dispatch({ type: 'CREATE_START' })
     try {
       await CreateProject(state.projectName, state.location, state.template, state.seedDemo)
@@ -74,7 +78,10 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
 
   const canContinue =
     (state.step === 1 && state.template !== null) ||
-    (state.step === 2 && state.projectName.trim() !== '' && state.location.trim() !== '')
+    (state.step === 2 &&
+      state.projectName.trim() !== '' &&
+      state.defaultProjectsDir.trim() !== '' &&
+      state.location.trim() !== '')
 
   const handleBrowseLocation = useCallback(async () => {
     try {
@@ -133,12 +140,11 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
             {state.step === 2 && (
               <WizardStepDetails
                 projectName={state.projectName}
+                projectsDir={state.defaultProjectsDir}
                 location={state.location}
                 seedDemo={state.seedDemo}
                 onNameChange={(name) => dispatch({ type: 'SET_PROJECT_NAME', name })}
-                onLocationChange={(location, manual) =>
-                  dispatch({ type: 'SET_LOCATION', location, manual })
-                }
+                onProjectsDirChange={(dir) => dispatch({ type: 'SET_DEFAULT_DIR', dir })}
                 onIncludeStarterChange={(include) => dispatch({ type: 'SET_SEED_DEMO', include })}
                 onBrowseLocation={handleBrowseLocation}
               />
@@ -163,11 +169,20 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
         </div>
 
         <div className="wizard__footer">
+          <button
+            className="button button--secondary button--md"
+            onClick={handleCancel}
+            disabled={state.creating}
+            type="button"
+          >
+            Cancel
+          </button>
           {state.step > 1 && (
             <button
               className="button button--secondary button--md"
               onClick={handleBack}
               disabled={state.creating}
+              type="button"
             >
               Back
             </button>
@@ -178,6 +193,7 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
               className="button button--primary button--md"
               onClick={handleContinue}
               disabled={!canContinue}
+              type="button"
             >
               Continue
             </button>
@@ -185,7 +201,8 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
             <button
               className="button button--primary button--md"
               onClick={handleCreate}
-              disabled={state.creating || !state.projectName.trim()}
+              disabled={state.creating || !state.projectName.trim() || !state.location.trim()}
+              type="button"
             >
               {state.creating ? 'Creating...' : 'Create Project'}
             </button>

--- a/frontend/src/components/project/NewProjectWizard.tsx
+++ b/frontend/src/components/project/NewProjectWizard.tsx
@@ -1,5 +1,5 @@
 import { useReducer, useEffect, useCallback } from 'react'
-import { wizardReducer, createInitialState, buildLocation } from './wizardReducer'
+import { wizardReducer, createInitialState } from './wizardReducer'
 import { WizardStepTemplate } from './WizardStepTemplate'
 import { WizardStepDetails } from './WizardStepDetails'
 import { WizardStepReview } from './WizardStepReview'
@@ -88,16 +88,11 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
       const dir = await OpenFolderDialog()
       if (!dir) return
 
-      dispatch({ type: 'SET_DEFAULT_DIR', dir })
-      dispatch({
-        type: 'SET_LOCATION',
-        location: buildLocation(state.projectName, dir),
-        manual: false,
-      })
+      dispatch({ type: 'SET_PROJECTS_DIR', dir, manual: true })
     } catch (err) {
       console.error('Browse location failed:', err)
     }
-  }, [state.projectName])
+  }, [])
 
   return (
     <div className="wizard-overlay">
@@ -144,7 +139,9 @@ export function NewProjectWizard({ onClose, onCreated }: NewProjectWizardProps) 
                 location={state.location}
                 seedDemo={state.seedDemo}
                 onNameChange={(name) => dispatch({ type: 'SET_PROJECT_NAME', name })}
-                onProjectsDirChange={(dir) => dispatch({ type: 'SET_DEFAULT_DIR', dir })}
+                onProjectsDirChange={(dir) =>
+                  dispatch({ type: 'SET_PROJECTS_DIR', dir, manual: true })
+                }
                 onIncludeStarterChange={(include) => dispatch({ type: 'SET_SEED_DEMO', include })}
                 onBrowseLocation={handleBrowseLocation}
               />

--- a/frontend/src/components/project/ProjectSwitcherDropdown.tsx
+++ b/frontend/src/components/project/ProjectSwitcherDropdown.tsx
@@ -121,6 +121,7 @@ export function ProjectSwitcherDropdown({
             projects={filteredRecents}
             onOpen={(path) => handleAction(() => onSwitchProject(path))}
             onRemove={(path) => handleAction(() => onRemoveRecentProject(path))}
+            itemRole="menuitem"
           />
         </>
       )}

--- a/frontend/src/components/project/RecentProjectsList.css
+++ b/frontend/src/components/project/RecentProjectsList.css
@@ -15,10 +15,10 @@
 
 .recent-projects__row {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: flex-start;
+  gap: 10px;
   width: 100%;
-  padding: var(--spacing-sm) var(--spacing-md);
+  padding: 8px 10px;
   background: none;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -36,6 +36,17 @@
 .recent-projects__row:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+}
+
+.recent-projects__icon {
+  margin-top: 1px;
+}
+
+.recent-projects__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .recent-projects__name {

--- a/frontend/src/components/project/RecentProjectsList.tsx
+++ b/frontend/src/components/project/RecentProjectsList.tsx
@@ -1,3 +1,4 @@
+import { FolderIcon } from '@components/ui/Icon'
 import './RecentProjectsList.css'
 
 export interface RecentProjectEntry {
@@ -11,6 +12,7 @@ interface RecentProjectsListProps {
   onOpen: (path: string) => void
   onRemove: (path: string) => void
   excludePaths?: Set<string>
+  itemRole?: string
 }
 
 function shortenPath(fullPath: string): string {
@@ -25,6 +27,7 @@ export function RecentProjectsList({
   onOpen,
   onRemove,
   excludePaths,
+  itemRole,
 }: RecentProjectsListProps) {
   const filtered = excludePaths ? projects.filter((p) => !excludePaths.has(p.path)) : projects
 
@@ -46,14 +49,22 @@ export function RecentProjectsList({
                 className="recent-projects__remove-btn"
                 onClick={() => onRemove(project.path)}
                 aria-label="Remove from list"
+                role={itemRole}
               >
                 Remove from list
               </button>
             </div>
           ) : (
-            <button className="recent-projects__row" onClick={() => onOpen(project.path)}>
-              <span className="recent-projects__name">{project.name}</span>
-              <span className="recent-projects__path">{shortenPath(project.path)}</span>
+            <button
+              className="recent-projects__row"
+              onClick={() => onOpen(project.path)}
+              role={itemRole}
+            >
+              <FolderIcon className="recent-projects__icon icon icon--md" aria-hidden="true" />
+              <span className="recent-projects__info">
+                <span className="recent-projects__name">{project.name}</span>
+                <span className="recent-projects__path">{shortenPath(project.path)}</span>
+              </span>
             </button>
           )}
         </li>

--- a/frontend/src/components/project/WelcomeScreen.css
+++ b/frontend/src/components/project/WelcomeScreen.css
@@ -1,69 +1,79 @@
 .welcome {
   grid-area: content;
   display: flex;
-  align-items: center;
   justify-content: center;
   background: var(--color-bg-base);
-  padding: var(--spacing-2xl);
+  overflow: auto;
+  padding: 40px 24px;
 }
 
 .welcome__container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--spacing-2xl);
-  max-width: 720px;
+  width: min(100%, 520px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: auto;
+  user-select: none;
+}
+
+.welcome__container > :first-child {
+  margin-top: auto;
+}
+
+.welcome__container > :last-child {
+  margin-bottom: auto;
+}
+
+.welcome__brand {
+  width: min(100%, 430px);
+  margin-bottom: 40px;
+}
+
+.welcome__logo {
+  display: block;
   width: 100%;
+  height: auto;
+  filter: drop-shadow(0 0 18px rgba(6, 182, 212, 0.2));
 }
 
-.welcome__left {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xl);
-}
-
-.welcome__branding {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-}
-
-.welcome__logo-text {
-  font-size: 28px;
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
-  letter-spacing: -0.02em;
-}
-
-.welcome__tagline {
-  font-size: var(--font-size-lg);
-  color: var(--color-text-secondary);
+.welcome__subcopy {
+  margin: 10px 0 0;
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
 }
 
 .welcome__actions {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: 10px;
+  width: 100%;
 }
 
 .welcome__action-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 24px;
   width: 100%;
+  min-height: 52px;
   padding: var(--spacing-sm) var(--spacing-md);
   font-family: var(--font-ui);
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-xl);
   color: var(--color-text-primary);
   background: var(--color-bg-hover);
-  border: 1px solid var(--color-border-muted);
+  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  box-shadow: var(--shadow-sm);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .welcome__action-btn:hover {
   background: var(--color-bg-active);
-  border-color: var(--color-border-default);
+  border-color: rgba(139, 158, 176, 0.38);
 }
 
 .welcome__action-btn:focus-visible {
@@ -77,15 +87,20 @@
 
 .welcome__kbd {
   font-family: var(--font-ui);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  padding: 2px 6px;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  padding: 4px 10px;
   background: var(--color-bg-panel);
   border: 1px solid var(--color-border-muted);
   border-radius: var(--radius-sm);
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
 }
 
 .welcome__compat-link {
+  align-self: flex-start;
+  margin-top: 20px;
   background: none;
   border: none;
   color: var(--color-text-secondary);
@@ -101,10 +116,13 @@
   color: var(--color-accent);
 }
 
-.welcome__right {
+.welcome__recent {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  width: 100%;
+  margin-top: 34px;
+  text-align: left;
 }
 
 .welcome__section-header {
@@ -114,4 +132,23 @@
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-wide);
   margin: 0;
+}
+
+@media (max-width: 640px) {
+  .welcome {
+    padding: 28px 16px;
+  }
+
+  .welcome__brand {
+    width: min(100%, 360px);
+    margin-bottom: 28px;
+  }
+
+  .welcome__action-btn {
+    font-size: var(--font-size-lg);
+  }
+
+  .welcome__compat-link {
+    margin-top: 16px;
+  }
 }

--- a/frontend/src/components/project/WelcomeScreen.tsx
+++ b/frontend/src/components/project/WelcomeScreen.tsx
@@ -1,4 +1,5 @@
 import { RecentProjectsList, type RecentProjectEntry } from './RecentProjectsList'
+import logoDark from '../../../../assets/branding/logo-dark.svg'
 import './WelcomeScreen.css'
 
 interface WelcomeScreenProps {
@@ -23,35 +24,31 @@ export function WelcomeScreen({
   return (
     <div className="welcome" data-testid="welcome-screen">
       <div className="welcome__container">
-        {/* Left Column — Branding + Actions */}
-        <div className="welcome__left">
-          <div className="welcome__branding">
-            <span className="welcome__logo-text">Flux</span>
-            <span className="welcome__tagline">The ML development environment</span>
-          </div>
+        <div className="welcome__brand">
+          <img className="welcome__logo" src={logoDark} alt="Flux" />
+          <p className="welcome__subcopy">Write code. Watch it learn.</p>
+        </div>
 
-          <div className="welcome__actions">
-            <button className="welcome__action-btn" onClick={onNewProject}>
-              <span className="welcome__action-label">New Project...</span>
-              <kbd className="welcome__kbd">⌘N</kbd>
-            </button>
-            <button className="welcome__action-btn" onClick={onOpenFolder}>
-              <span className="welcome__action-label">Open Folder...</span>
-              <kbd className="welcome__kbd">⌘O</kbd>
-            </button>
-            <button className="welcome__action-btn" onClick={onOpenExisting}>
-              <span className="welcome__action-label">Open Existing Project...</span>
-              <kbd className="welcome__kbd">⇧⌘O</kbd>
-            </button>
-          </div>
-
-          <button className="welcome__compat-link" onClick={onBrowseExperiments}>
-            Browse Existing Experiments
+        <div className="welcome__actions">
+          <button className="welcome__action-btn" onClick={onNewProject}>
+            <span className="welcome__action-label">New Project...</span>
+            <kbd className="welcome__kbd">⌘N</kbd>
+          </button>
+          <button className="welcome__action-btn" onClick={onOpenFolder}>
+            <span className="welcome__action-label">Open Folder...</span>
+            <kbd className="welcome__kbd">⌘O</kbd>
+          </button>
+          <button className="welcome__action-btn" onClick={onOpenExisting}>
+            <span className="welcome__action-label">Open Existing Project...</span>
+            <kbd className="welcome__kbd">⇧⌘O</kbd>
           </button>
         </div>
 
-        {/* Right Column — Recent Projects */}
-        <div className="welcome__right">
+        <button className="welcome__compat-link" onClick={onBrowseExperiments}>
+          Browse Existing Experiments
+        </button>
+
+        <div className="welcome__recent">
           <h2 className="welcome__section-header">Recent Projects</h2>
           <RecentProjectsList
             projects={recentProjects}

--- a/frontend/src/components/project/WizardStepDetails.tsx
+++ b/frontend/src/components/project/WizardStepDetails.tsx
@@ -1,19 +1,21 @@
 interface WizardStepDetailsProps {
   projectName: string
+  projectsDir: string
   location: string
   seedDemo: boolean
   onNameChange: (name: string) => void
-  onLocationChange: (location: string, manual: boolean) => void
+  onProjectsDirChange: (dir: string) => void
   onIncludeStarterChange: (include: boolean) => void
   onBrowseLocation: () => void
 }
 
 export function WizardStepDetails({
   projectName,
+  projectsDir,
   location,
   seedDemo,
   onNameChange,
-  onLocationChange,
+  onProjectsDirChange,
   onIncludeStarterChange,
   onBrowseLocation,
 }: WizardStepDetailsProps) {
@@ -37,15 +39,15 @@ export function WizardStepDetails({
 
       <div className="wizard-field">
         <label htmlFor="wizard-location" className="wizard-field__label">
-          Location
+          Projects Folder
         </label>
         <div className="wizard-field__row">
           <input
             id="wizard-location"
             type="text"
             className="input"
-            value={location}
-            onChange={(e) => onLocationChange(e.target.value, true)}
+            value={projectsDir}
+            onChange={(e) => onProjectsDirChange(e.target.value)}
           />
           <button
             className="button button--secondary button--md"
@@ -55,6 +57,11 @@ export function WizardStepDetails({
             Browse...
           </button>
         </div>
+        {location && (
+          <div className="wizard-field__hint">
+            Project path: <code>{location}</code>
+          </div>
+        )}
       </div>
 
       <div className="wizard-field wizard-field--toggle">
@@ -63,11 +70,11 @@ export function WizardStepDetails({
             type="checkbox"
             checked={seedDemo}
             onChange={(e) => onIncludeStarterChange(e.target.checked)}
-            aria-label="Include starter experiments"
+            aria-label="Add demo experiments to Flux"
           />
-          <span className="wizard-toggle__label">Include starter experiments</span>
+          <span className="wizard-toggle__label">Add demo experiments to Flux</span>
           <span className="wizard-toggle__desc">
-            Populates charts with sample training runs matching your project type.
+            Seeds Flux's local database with sample runs for this project.
           </span>
         </label>
       </div>

--- a/frontend/src/components/project/WizardStepReview.tsx
+++ b/frontend/src/components/project/WizardStepReview.tsx
@@ -31,7 +31,7 @@ export function WizardStepReview({
           <dd className="wizard-review__value wizard-review__value--mono">{location}</dd>
         </div>
         <div className="wizard-review__row">
-          <dt className="wizard-review__label">Starter Experiments</dt>
+          <dt className="wizard-review__label">Flux Demo Experiments</dt>
           <dd className="wizard-review__value">{seedDemo ? 'Yes' : 'No'}</dd>
         </div>
       </dl>

--- a/frontend/src/components/project/WizardSummaryRail.tsx
+++ b/frontend/src/components/project/WizardSummaryRail.tsx
@@ -34,7 +34,7 @@ export function WizardSummaryRail({
         </div>
       )}
       <div className="wizard-rail__item">
-        <span className="wizard-rail__label">Starter data</span>
+        <span className="wizard-rail__label">Flux demo data</span>
         <span className="wizard-rail__value">{seedDemo ? 'Yes' : 'No'}</span>
       </div>
     </aside>

--- a/frontend/src/components/project/wizardReducer.ts
+++ b/frontend/src/components/project/wizardReducer.ts
@@ -12,6 +12,7 @@ export interface WizardState {
   location: string
   defaultProjectsDir: string
   locationManuallyEdited: boolean
+  projectsDirManuallyEdited: boolean
   seedDemo: boolean
   creating: boolean
   error: string | null
@@ -23,6 +24,7 @@ export type WizardAction =
   | { type: 'SET_LOCATION'; location: string; manual: boolean }
   | { type: 'SET_SEED_DEMO'; include: boolean }
   | { type: 'SET_DEFAULT_DIR'; dir: string }
+  | { type: 'SET_PROJECTS_DIR'; dir: string; manual: boolean }
   | { type: 'GO_TO_STEP'; step: 1 | 2 | 3 }
   | { type: 'CREATE_START' }
   | { type: 'CREATE_ERROR'; error: string }
@@ -59,6 +61,7 @@ export function createInitialState(defaultProjectsDir = ''): WizardState {
     location: '',
     defaultProjectsDir,
     locationManuallyEdited: false,
+    projectsDirManuallyEdited: false,
     seedDemo: false,
     creating: false,
     error: null,
@@ -86,7 +89,19 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       return next
     }
     case 'SET_DEFAULT_DIR': {
+      if (state.projectsDirManuallyEdited) return state
       const next: WizardState = { ...state, defaultProjectsDir: action.dir }
+      if (!state.locationManuallyEdited && state.projectName.trim() !== '') {
+        next.location = buildLocation(state.projectName, action.dir)
+      }
+      return next
+    }
+    case 'SET_PROJECTS_DIR': {
+      const next: WizardState = {
+        ...state,
+        defaultProjectsDir: action.dir,
+        projectsDirManuallyEdited: action.manual || state.projectsDirManuallyEdited,
+      }
       if (!state.locationManuallyEdited && state.projectName.trim() !== '') {
         next.location = buildLocation(state.projectName, action.dir)
       }

--- a/frontend/src/components/project/wizardReducer.ts
+++ b/frontend/src/components/project/wizardReducer.ts
@@ -33,6 +33,11 @@ const DEFAULT_NAMES: Record<TemplateId, string> = {
   blank: 'my-project',
 }
 
+const DEFAULT_SEED_DEMO: Record<TemplateId, boolean> = {
+  'reward-model': true,
+  blank: false,
+}
+
 function sanitizeForPath(name: string): string {
   return name
     .toLowerCase()
@@ -54,7 +59,7 @@ export function createInitialState(defaultProjectsDir = ''): WizardState {
     location: '',
     defaultProjectsDir,
     locationManuallyEdited: false,
-    seedDemo: true,
+    seedDemo: false,
     creating: false,
     error: null,
   }
@@ -70,6 +75,7 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
         projectName: name,
         location: buildLocation(name, state.defaultProjectsDir),
         locationManuallyEdited: false,
+        seedDemo: DEFAULT_SEED_DEMO[action.template],
       }
     }
     case 'SET_PROJECT_NAME': {

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,12 @@ interface UseKeyboardShortcutsOptions {
   onNewProject?: () => void
   onOpenFolder?: () => void
   onOpenExisting?: () => void
+  projectActionsDisabled?: boolean
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
 }
 
 export function useKeyboardShortcuts({
@@ -24,25 +30,18 @@ export function useKeyboardShortcuts({
   onNewProject,
   onOpenFolder,
   onOpenExisting,
+  projectActionsDisabled,
 }: UseKeyboardShortcutsOptions) {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       // Check for Cmd (Mac) or Ctrl (Windows/Linux)
       const isMod = event.metaKey || event.ctrlKey
+      const normalizedKey = event.key.toLowerCase()
 
       if (!isMod) return
 
-      // Don't fire project shortcuts (N, O) when typing in form fields
-      if (event.key === 'n' || event.key === 'o') {
-        const target = event.target as HTMLElement
-        if (
-          target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable
-        ) {
-          return
-        }
-      }
+      // Don't fire app shortcuts while typing or when a modal owns the interaction.
+      if (isEditableTarget(event.target) || projectActionsDisabled) return
 
       // View switching: Cmd/Ctrl + 1-4
       if (event.key in VIEW_SHORTCUTS && onViewChange) {
@@ -61,21 +60,21 @@ export function useKeyboardShortcuts({
       }
 
       // New project: Cmd/Ctrl + N
-      if (event.key === 'n' && !event.shiftKey && onNewProject) {
+      if (normalizedKey === 'n' && !event.shiftKey && onNewProject) {
         event.preventDefault()
         onNewProject()
         return
       }
 
       // Open folder: Cmd/Ctrl + O
-      if (event.key === 'o' && !event.shiftKey && onOpenFolder) {
+      if (normalizedKey === 'o' && !event.shiftKey && onOpenFolder) {
         event.preventDefault()
         onOpenFolder()
         return
       }
 
       // Open existing project: Cmd/Ctrl + Shift + O
-      if (event.key === 'O' && event.shiftKey && onOpenExisting) {
+      if (normalizedKey === 'o' && event.shiftKey && onOpenExisting) {
         event.preventDefault()
         onOpenExisting()
         return
@@ -84,5 +83,13 @@ export function useKeyboardShortcuts({
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onViewChange, onCommandPalette, disabledViews, onNewProject, onOpenFolder, onOpenExisting])
+  }, [
+    onViewChange,
+    onCommandPalette,
+    disabledViews,
+    onNewProject,
+    onOpenFolder,
+    onOpenExisting,
+    projectActionsDisabled,
+  ])
 }

--- a/frontend/src/styles/components/layout.css
+++ b/frontend/src/styles/components/layout.css
@@ -22,6 +22,46 @@
   background-color: var(--color-bg-base);
 }
 
+.app-shell__notice {
+  position: fixed;
+  top: calc(var(--header-height) + var(--spacing-md));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 250;
+  width: min(680px, calc(100vw - 2 * var(--spacing-lg)));
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: rgba(13, 17, 23, 0.96);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(8px);
+}
+
+.app-shell__notice--error {
+  border: 1px solid var(--color-error);
+}
+
+.app-shell__notice-message {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+}
+
+.app-shell__notice-dismiss {
+  font-family: var(--font-ui);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.app-shell__notice-dismiss:hover {
+  color: var(--color-text-primary);
+}
+
 /* ========================================
  * Title Bar (transparent macOS title bar)
  *

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,7 +15,11 @@ export default defineConfig({
       '@assets': path.resolve(__dirname, './src/assets'),
     },
   },
-  server: {},
+  server: {
+    fs: {
+      allow: [path.resolve(__dirname, '..')],
+    },
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -3,15 +3,23 @@
 import {event} from '../models';
 import {annotation} from '../models';
 import {experiment} from '../models';
+import {project} from '../models';
 import {main} from '../models';
 import {metrics} from '../models';
-import {project} from '../models';
 
 export function AppendEvent(arg1:string,arg2:string,arg3:string):Promise<event.Event>;
+
+export function ClaimExperimentToCurrentProject(arg1:string):Promise<void>;
+
+export function ClaimExperimentToProject(arg1:string,arg2:string):Promise<void>;
+
+export function CloseProject():Promise<void>;
 
 export function CreateAnnotation(arg1:string,arg2:number,arg3:string,arg4:string,arg5:string):Promise<annotation.Annotation>;
 
 export function CreateExperiment(arg1:string,arg2:string):Promise<experiment.Experiment>;
+
+export function CreateProject(arg1:string,arg2:string,arg3:string,arg4:boolean):Promise<project.Project>;
 
 export function DeleteAnnotation(arg1:string,arg2:number):Promise<void>;
 
@@ -19,7 +27,13 @@ export function DeleteExperiment(arg1:string):Promise<void>;
 
 export function GetAppInfo():Promise<main.AppInfo>;
 
+export function GetCurrentProject():Promise<project.Project>;
+
+export function GetCurrentProjectStatus():Promise<main.CurrentProjectStatus>;
+
 export function GetDBStatus():Promise<string>;
+
+export function GetDefaultProjectsDir():Promise<string>;
 
 export function GetExperiment(arg1:string):Promise<experiment.Experiment>;
 
@@ -27,9 +41,23 @@ export function GetLatestMetrics(arg1:string):Promise<Array<metrics.Metric>>;
 
 export function GetLayout():Promise<main.LayoutState>;
 
+export function GetProjectConfig(arg1:string):Promise<project.FluxConfig>;
+
 export function Greet(arg1:string):Promise<string>;
 
+export function IsFluxProject(arg1:string):Promise<boolean>;
+
 export function ListExperiments():Promise<Array<experiment.Experiment>>;
+
+export function ListRecentProjects():Promise<Array<project.RecentProject>>;
+
+export function ListUnscopedExperiments():Promise<Array<experiment.Experiment>>;
+
+export function OpenFolderAsProject(arg1:string,arg2:string,arg3:boolean):Promise<project.Project>;
+
+export function OpenFolderDialog():Promise<string>;
+
+export function OpenProject(arg1:string):Promise<project.Project>;
 
 export function QueryAnnotations(arg1:string,arg2:string,arg3:number,arg4:number):Promise<Array<annotation.Annotation>>;
 
@@ -41,39 +69,11 @@ export function RecordMetrics(arg1:string,arg2:Array<metrics.Metric>):Promise<vo
 
 export function RecordRewardSignals(arg1:string,arg2:Array<metrics.RewardSignal>):Promise<void>;
 
+export function RemoveRecentProject(arg1:string):Promise<void>;
+
 export function ReplayEvents(arg1:string,arg2:number,arg3:number,arg4:string):Promise<Array<event.Event>>;
 
 export function SaveLayout(arg1:main.LayoutState):Promise<void>;
-
-export function ClaimExperimentToCurrentProject(arg1:string):Promise<void>;
-
-export function ClaimExperimentToProject(arg1:string,arg2:string):Promise<void>;
-
-export function CloseProject():Promise<void>;
-
-export function CreateProject(arg1:string,arg2:string,arg3:string,arg4:boolean):Promise<project.Project>;
-
-export function GetCurrentProject():Promise<project.Project>;
-
-export function GetCurrentProjectStatus():Promise<main.CurrentProjectStatus>;
-
-export function GetProjectConfig(arg1:string):Promise<project.FluxConfig>;
-
-export function IsFluxProject(arg1:string):Promise<boolean>;
-
-export function GetDefaultProjectsDir():Promise<string>;
-
-export function ListRecentProjects():Promise<Array<project.RecentProject>>;
-
-export function OpenFolderDialog():Promise<string>;
-
-export function RemoveRecentProject(arg1:string):Promise<void>;
-
-export function ListUnscopedExperiments():Promise<Array<experiment.Experiment>>;
-
-export function OpenFolderAsProject(arg1:string,arg2:string,arg3:boolean):Promise<project.Project>;
-
-export function OpenProject(arg1:string):Promise<project.Project>;
 
 export function ToggleMaximize():Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,12 +6,28 @@ export function AppendEvent(arg1, arg2, arg3) {
   return window['go']['main']['App']['AppendEvent'](arg1, arg2, arg3);
 }
 
+export function ClaimExperimentToCurrentProject(arg1) {
+  return window['go']['main']['App']['ClaimExperimentToCurrentProject'](arg1);
+}
+
+export function ClaimExperimentToProject(arg1, arg2) {
+  return window['go']['main']['App']['ClaimExperimentToProject'](arg1, arg2);
+}
+
+export function CloseProject() {
+  return window['go']['main']['App']['CloseProject']();
+}
+
 export function CreateAnnotation(arg1, arg2, arg3, arg4, arg5) {
   return window['go']['main']['App']['CreateAnnotation'](arg1, arg2, arg3, arg4, arg5);
 }
 
 export function CreateExperiment(arg1, arg2) {
   return window['go']['main']['App']['CreateExperiment'](arg1, arg2);
+}
+
+export function CreateProject(arg1, arg2, arg3, arg4) {
+  return window['go']['main']['App']['CreateProject'](arg1, arg2, arg3, arg4);
 }
 
 export function DeleteAnnotation(arg1, arg2) {
@@ -26,8 +42,20 @@ export function GetAppInfo() {
   return window['go']['main']['App']['GetAppInfo']();
 }
 
+export function GetCurrentProject() {
+  return window['go']['main']['App']['GetCurrentProject']();
+}
+
+export function GetCurrentProjectStatus() {
+  return window['go']['main']['App']['GetCurrentProjectStatus']();
+}
+
 export function GetDBStatus() {
   return window['go']['main']['App']['GetDBStatus']();
+}
+
+export function GetDefaultProjectsDir() {
+  return window['go']['main']['App']['GetDefaultProjectsDir']();
 }
 
 export function GetExperiment(arg1) {
@@ -42,12 +70,40 @@ export function GetLayout() {
   return window['go']['main']['App']['GetLayout']();
 }
 
+export function GetProjectConfig(arg1) {
+  return window['go']['main']['App']['GetProjectConfig'](arg1);
+}
+
 export function Greet(arg1) {
   return window['go']['main']['App']['Greet'](arg1);
 }
 
+export function IsFluxProject(arg1) {
+  return window['go']['main']['App']['IsFluxProject'](arg1);
+}
+
 export function ListExperiments() {
   return window['go']['main']['App']['ListExperiments']();
+}
+
+export function ListRecentProjects() {
+  return window['go']['main']['App']['ListRecentProjects']();
+}
+
+export function ListUnscopedExperiments() {
+  return window['go']['main']['App']['ListUnscopedExperiments']();
+}
+
+export function OpenFolderAsProject(arg1, arg2, arg3) {
+  return window['go']['main']['App']['OpenFolderAsProject'](arg1, arg2, arg3);
+}
+
+export function OpenFolderDialog() {
+  return window['go']['main']['App']['OpenFolderDialog']();
+}
+
+export function OpenProject(arg1) {
+  return window['go']['main']['App']['OpenProject'](arg1);
 }
 
 export function QueryAnnotations(arg1, arg2, arg3, arg4) {
@@ -70,72 +126,16 @@ export function RecordRewardSignals(arg1, arg2) {
   return window['go']['main']['App']['RecordRewardSignals'](arg1, arg2);
 }
 
+export function RemoveRecentProject(arg1) {
+  return window['go']['main']['App']['RemoveRecentProject'](arg1);
+}
+
 export function ReplayEvents(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['ReplayEvents'](arg1, arg2, arg3, arg4);
 }
 
 export function SaveLayout(arg1) {
   return window['go']['main']['App']['SaveLayout'](arg1);
-}
-
-export function ClaimExperimentToCurrentProject(arg1) {
-  return window['go']['main']['App']['ClaimExperimentToCurrentProject'](arg1);
-}
-
-export function ClaimExperimentToProject(arg1, arg2) {
-  return window['go']['main']['App']['ClaimExperimentToProject'](arg1, arg2);
-}
-
-export function CloseProject() {
-  return window['go']['main']['App']['CloseProject']();
-}
-
-export function CreateProject(arg1, arg2, arg3, arg4) {
-  return window['go']['main']['App']['CreateProject'](arg1, arg2, arg3, arg4);
-}
-
-export function GetCurrentProject() {
-  return window['go']['main']['App']['GetCurrentProject']();
-}
-
-export function GetCurrentProjectStatus() {
-  return window['go']['main']['App']['GetCurrentProjectStatus']();
-}
-
-export function GetProjectConfig(arg1) {
-  return window['go']['main']['App']['GetProjectConfig'](arg1);
-}
-
-export function IsFluxProject(arg1) {
-  return window['go']['main']['App']['IsFluxProject'](arg1);
-}
-
-export function GetDefaultProjectsDir() {
-  return window['go']['main']['App']['GetDefaultProjectsDir']();
-}
-
-export function ListRecentProjects() {
-  return window['go']['main']['App']['ListRecentProjects']();
-}
-
-export function OpenFolderDialog() {
-  return window['go']['main']['App']['OpenFolderDialog']();
-}
-
-export function RemoveRecentProject(arg1) {
-  return window['go']['main']['App']['RemoveRecentProject'](arg1);
-}
-
-export function ListUnscopedExperiments() {
-  return window['go']['main']['App']['ListUnscopedExperiments']();
-}
-
-export function OpenFolderAsProject(arg1, arg2, arg3) {
-  return window['go']['main']['App']['OpenFolderAsProject'](arg1, arg2, arg3);
-}
-
-export function OpenProject(arg1) {
-  return window['go']['main']['App']['OpenProject'](arg1);
 }
 
 export function ToggleMaximize() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,5 +1,5 @@
 export namespace annotation {
-	
+
 	export class Annotation {
 	    id: number;
 	    experiment_id: string;
@@ -8,11 +8,11 @@ export namespace annotation {
 	    label: string;
 	    data: string;
 	    created_at: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Annotation(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -28,18 +28,18 @@ export namespace annotation {
 }
 
 export namespace event {
-	
+
 	export class Event {
 	    id: number;
 	    experiment_id: string;
 	    timestamp: number;
 	    type: string;
 	    data: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Event(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -53,7 +53,7 @@ export namespace event {
 }
 
 export namespace experiment {
-	
+
 	export class Experiment {
 	    id: string;
 	    name: string;
@@ -84,15 +84,15 @@ export namespace experiment {
 }
 
 export namespace main {
-	
+
 	export class AppInfo {
 	    name: string;
 	    version: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new AppInfo(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
@@ -102,8 +102,8 @@ export namespace main {
 	export class CurrentProjectStatus {
 	    project?: project.Project;
 	    config?: project.FluxConfig;
-	    configError: string;
-	    warnings: string[];
+	    configError?: string;
+	    warnings?: string[];
 	    degraded: boolean;
 
 	    static createFrom(source: any = {}) {
@@ -112,12 +112,30 @@ export namespace main {
 
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.project = source["project"] ? project.Project.createFrom(source["project"]) : undefined;
-	        this.config = source["config"] ? project.FluxConfig.createFrom(source["config"]) : undefined;
+	        this.project = this.convertValues(source["project"], project.Project);
+	        this.config = this.convertValues(source["config"], project.FluxConfig);
 	        this.configError = source["configError"];
-	        this.warnings = source["warnings"] || [];
+	        this.warnings = source["warnings"];
 	        this.degraded = source["degraded"];
 	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class LayoutState {
 	    leftWidth: number;
@@ -128,11 +146,11 @@ export namespace main {
 	    leftCollapsed: boolean;
 	    rightCollapsed: boolean;
 	    outputCollapsed: boolean;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new LayoutState(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.leftWidth = source["leftWidth"];
@@ -149,18 +167,18 @@ export namespace main {
 }
 
 export namespace metrics {
-	
+
 	export class Metric {
 	    experiment_id: string;
 	    step: number;
 	    name: string;
 	    value: number;
 	    timestamp: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Metric(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.experiment_id = source["experiment_id"];
@@ -176,11 +194,11 @@ export namespace metrics {
 	    component: string;
 	    value: number;
 	    distribution: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new RewardSignal(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.experiment_id = source["experiment_id"];
@@ -200,7 +218,7 @@ export namespace project {
 	    name: string;
 	    description?: string;
 	    ignore?: string[];
-	    defaults?: {[key: string]: string};
+	    defaults?: Record<string, string>;
 
 	    static createFrom(source: any = {}) {
 	        return new FluxConfig(source);

--- a/internal/project/path.go
+++ b/internal/project/path.go
@@ -9,8 +9,8 @@ import (
 // CanonicalProjectPath returns a normalized, absolute, symlink-resolved path
 // suitable for use as a stable project identity key.
 //
-// If the path does not yet exist (e.g. scaffold target), EvalSymlinks will fail
-// and we fall back to the cleaned absolute path.
+// If the final path does not yet exist (e.g. scaffold target), the nearest
+// existing parent is symlink-resolved and the missing suffix is appended.
 func CanonicalProjectPath(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("project path cannot be empty")
@@ -25,10 +25,34 @@ func CanonicalProjectPath(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(abs)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return abs, nil
+			return resolveExistingParent(abs)
 		}
 		return "", fmt.Errorf("resolving symlinks: %w", err)
 	}
 
 	return resolved, nil
+}
+
+func resolveExistingParent(abs string) (string, error) {
+	missingParts := []string{}
+	candidate := abs
+
+	for {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err == nil {
+			parts := append([]string{resolved}, missingParts...)
+			return filepath.Join(parts...), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolving symlinks: %w", err)
+		}
+
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return abs, nil
+		}
+
+		missingParts = append([]string{filepath.Base(candidate)}, missingParts...)
+		candidate = parent
+	}
 }

--- a/internal/project/path_test.go
+++ b/internal/project/path_test.go
@@ -68,6 +68,11 @@ func TestCanonicalProjectPath_ResolvesSymlinks(t *testing.T) {
 func TestCanonicalProjectPath_NonExistentFallback(t *testing.T) {
 	dir := t.TempDir()
 	nonExistent := filepath.Join(dir, "does-not-exist")
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolving temp dir: %v", err)
+	}
+	expected := filepath.Join(resolvedDir, "does-not-exist")
 
 	got, err := CanonicalProjectPath(nonExistent)
 	if err != nil {
@@ -76,8 +81,32 @@ func TestCanonicalProjectPath_NonExistentFallback(t *testing.T) {
 	if !filepath.IsAbs(got) {
 		t.Errorf("result %q is not absolute", got)
 	}
-	if got != nonExistent {
-		t.Errorf("got %q, want %q (cleaned absolute path)", got, nonExistent)
+	if got != expected {
+		t.Errorf("got %q, want %q (resolved parent plus missing leaf)", got, expected)
+	}
+}
+
+func TestCanonicalProjectPath_ResolvesSymlinkParentForNonExistentLeaf(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real")
+	link := filepath.Join(dir, "link")
+	if err := os.Mkdir(real, 0755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	gotReal, err := CanonicalProjectPath(filepath.Join(real, "new-project"))
+	if err != nil {
+		t.Fatalf("canonical real child: %v", err)
+	}
+	gotLink, err := CanonicalProjectPath(filepath.Join(link, "new-project"))
+	if err != nil {
+		t.Fatalf("canonical link child: %v", err)
+	}
+	if gotReal != gotLink {
+		t.Errorf("real child=%q link child=%q — should be identical after canonicalization", gotReal, gotLink)
 	}
 }
 

--- a/project_api.go
+++ b/project_api.go
@@ -40,7 +40,6 @@ func (a *App) CreateProject(name, dir, template string, seedDemo bool) (*project
 		return nil, fmt.Errorf("scaffolding project: %w", err)
 	}
 
-	// Seed demo data if requested
 	if seedDemo {
 		a.seedProjectData(proj.ID)
 	}
@@ -185,7 +184,8 @@ func (a *App) OpenFolderDialog() (string, error) {
 		return "", fmt.Errorf("application context not initialized")
 	}
 	return wailsRuntime.OpenDirectoryDialog(a.ctx, wailsRuntime.OpenDialogOptions{
-		Title: "Select Folder",
+		Title:                "Select Folder",
+		CanCreateDirectories: true,
 	})
 }
 
@@ -227,6 +227,8 @@ func (a *App) setCurrentProject(proj *project.Project, dir string) error {
 }
 
 // seedProjectData seeds demo experiments and metrics for a project.
+// TODO: Move demo project data into project-folder artifacts so sample
+// experiments travel with the folder instead of only living in Flux's DB.
 func (a *App) seedProjectData(projectID string) {
 	if a.experiments != nil {
 		if err := a.experiments.SeedDemoExperiments(projectID); err != nil {


### PR DESCRIPTION
## Summary
- addresses PR #118 test-plan follow-ups in a new branch after the original branch was deleted
- clarifies New Project base folder behavior and adds wizard Cancel
- fixes Open Folder/open existing refresh and stale recent-project error handling
- renames the sample-data toggle to clarify that it seeds Flux's local DB, with a TODO for folder-backed demo data later
- fixes canonical project path handling so reopened seeded projects load their experiments

## Verification
- npm test -- --runInBand
- npm run typecheck
- npm run lint
- go test ./...
- git diff --check